### PR TITLE
feat: update speaking page with recent talks

### DIFF
--- a/daniakash.com/src/content/speaking/events.json
+++ b/daniakash.com/src/content/speaking/events.json
@@ -26,6 +26,52 @@
     ]
   },
   {
+    "year": 2025,
+    "events": [
+      {
+        "date": "Dec 13, 2025",
+        "name": "React Meetup #96",
+        "title": "Building an AI Agent",
+        "description": "A live coding session on building a Claude or Codex-style CLI agent from scratch using simple JavaScript and terminal-first tooling.",
+        "cta": [
+          {
+            "title": "Event Website",
+            "url": "https://www.meetup.com/reactjs-bangalore/events/311744342/?eventOrigin=group_events_list"
+          },
+          {
+            "title": "Community",
+            "url": "https://www.meetup.com/reactjs-bangalore/"
+          },
+          {
+            "title": "Code",
+            "url": "https://github.com/DaniAkash/building-an-agent"
+          }
+        ]
+      },
+      {
+        "date": "Nov 29, 2025",
+        "name": "Chennai React Meetup #15",
+        "title": "Unlock Server Side Rendering with Nitro",
+        "description": "A simple walkthrough of converting a legacy site to SSR with Vite and Nitro, using a before-and-after app structure to explain the migration path.",
+        "video": "https://www.youtube.com/live/0NYbRQtaYhs?si=oDyUTKSDwHWI0E92&t=208",
+        "cta": [
+          {
+            "title": "Event Website",
+            "url": "https://luma.com/g6aqpnb2"
+          },
+          {
+            "title": "Community",
+            "url": "https://www.chennaireact.in/socials"
+          },
+          {
+            "title": "Code",
+            "url": "https://github.com/DaniAkash/unlock-server-rendering"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "year": 2024,
     "events": [
       {

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -38,6 +38,7 @@ const eventsList = events[0]!;
                         const youtubeThumbnail = getYoutubeThumbnail(
                           event.video ?? "",
                         );
+                        const primaryLink = event.video ?? event.cta?.[0]?.url;
                         return (
                           <article class="group relative flex flex-col items-start">
                             {event.thumbnail ? (
@@ -58,16 +59,20 @@ const eventsList = events[0]!;
                             ) : null}
                             <h3 class="mt-4 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
                               <div class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl" />
-                              <a
-                                href={event.video}
-                                target="_blank"
-                                rel="noopener"
-                              >
-                                <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
-                                <span class="relative z-10">
-                                  {event.title}
-                                </span>
-                              </a>
+                              {primaryLink ? (
+                                <a
+                                  href={primaryLink}
+                                  target="_blank"
+                                  rel="noopener"
+                                >
+                                  <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
+                                  <span class="relative z-10">
+                                    {event.title}
+                                  </span>
+                                </a>
+                              ) : (
+                                <span class="relative z-10">{event.title}</span>
+                              )}
                             </h3>
                             <p class="relative z-10 order-first mb-3 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500">
                               <span

--- a/daniakash.com/src/utils/getYoutubeThumbnail.ts
+++ b/daniakash.com/src/utils/getYoutubeThumbnail.ts
@@ -1,20 +1,21 @@
 const extractYouTubeVideoId = (url: string) => {
   try {
     const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname.replace(/^www\./, "");
 
     // Check if it's a YouTube URL
-    if (
-      parsedUrl.hostname === "www.youtube.com" ||
-      parsedUrl.hostname === "youtube.com"
-    ) {
+    if (hostname === "youtube.com") {
+      if (parsedUrl.pathname.startsWith("/live/")) {
+        return parsedUrl.pathname.split("/")[2] ?? null; // for "youtube.com/live/VIDEO_ID" format
+      }
+
+      if (parsedUrl.pathname.startsWith("/embed/")) {
+        return parsedUrl.pathname.split("/")[2] ?? null; // for "youtube.com/embed/VIDEO_ID" format
+      }
+
       return parsedUrl.searchParams.get("v"); // for "watch?v=VIDEO_ID" format
-    } else if (parsedUrl.hostname === "youtu.be") {
+    } else if (hostname === "youtu.be") {
       return parsedUrl.pathname.slice(1); // for "youtu.be/VIDEO_ID" format
-    } else if (
-      parsedUrl.hostname === "www.youtube.com" &&
-      parsedUrl.pathname.startsWith("/embed/")
-    ) {
-      return parsedUrl.pathname.split("/")[2]; // for "youtube.com/embed/VIDEO_ID" format
     }
 
     return null; // Return null if URL is not a recognized YouTube format


### PR DESCRIPTION
## Summary
- add the 2025 speaking entries for Building an AI Agent and Unlock Server Side Rendering with Nitro
- keep the speaking page resilient when an event has no recording link by falling back to the event URL
- build this branch cleanly from main instead of stacking on an older speaking branch