### PR TITLE
feat: redesign homepage as markdown-style document

### DIFF
--- a/daniakash.com/package.json
+++ b/daniakash.com/package.json
@@ -24,6 +24,9 @@
     "typescript": "^6.0.2"
   },
   "devDependencies": {
+    "@fontsource/monaspace-neon": "^5.2.5",
+    "@fontsource/monaspace-radon": "^5.2.5",
+    "@fontsource/monaspace-xenon": "^5.2.5",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@types/markdown-it": "^14.1.2",

--- a/daniakash.com/pnpm-lock.yaml
+++ b/daniakash.com/pnpm-lock.yaml
@@ -42,6 +42,15 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
     devDependencies:
+      '@fontsource/monaspace-neon':
+        specifier: ^5.2.5
+        version: 5.2.5
+      '@fontsource/monaspace-radon':
+        specifier: ^5.2.5
+        version: 5.2.5
+      '@fontsource/monaspace-xenon':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.2)
@@ -433,6 +442,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/monaspace-neon@5.2.5':
+    resolution: {integrity: sha512-TjSSuHC37DroyhP5YCKRCAxdUb3In/uqHzqqW/8Ul+JWilz37d8lr8jFeapnbD3QdYXgiQoU2Rf/CmTdyl06DA==}
+
+  '@fontsource/monaspace-radon@5.2.5':
+    resolution: {integrity: sha512-mG6ltrFW5BYmcoRvVIKboCORZu8BeGg6h5zV5rnwEmFcjv8Bltua3KOj6aOxWbrR4PYnKyR17lNqSsjR8kx4bQ==}
+
+  '@fontsource/monaspace-xenon@5.2.5':
+    resolution: {integrity: sha512-k10RCF5nek9ee/rKSALaeYgOcJjjvzxxGkIlPwkSAoasjrsEeVKOSJ6ii1dMXOZwL9ZtW3p56Dxhgaw0Gtwvaw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3066,6 +3084,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@fontsource/monaspace-neon@5.2.5': {}
+
+  '@fontsource/monaspace-radon@5.2.5': {}
+
+  '@fontsource/monaspace-xenon@5.2.5': {}
 
   '@img/colour@1.1.0': {}
 

--- a/daniakash.com/src/components/Article.astro
+++ b/daniakash.com/src/components/Article.astro
@@ -27,6 +27,10 @@ const dateValue = getDateValue(date);
     class="absolute -inset-x-2 -inset-y-3 z-20 text-[0px]"
     >{title}</a
   >
+  <div
+    class="page-hover-frame absolute -inset-x-3 -inset-y-4 z-0"
+  >
+  </div>
   <h2
     class="relative z-10 text-[1.18rem] font-semibold leading-8 tracking-tight"
     style="color: var(--page-heading);"
@@ -39,8 +43,7 @@ const dateValue = getDateValue(date);
     {subtitle}
   </p>
   <div
-    class="font-editorial-sans relative z-10 mt-3 flex items-center gap-2 text-[0.74rem] font-medium uppercase tracking-[0.16em]"
-    style="color: var(--page-link);"
+    class="font-editorial-sans relative z-10 mt-3 flex items-center gap-2 text-[0.74rem] font-medium uppercase tracking-[0.16em] text-[color:var(--page-link)]"
   >
     Read article
     <span aria-hidden="true">→</span>

--- a/daniakash.com/src/components/Article.astro
+++ b/daniakash.com/src/components/Article.astro
@@ -1,5 +1,6 @@
 ---
 import type { InferEntrySchema } from "astro:content";
+import { fade } from "astro:transitions";
 import { TRANSITION_NAMES } from "../constants/transition-names";
 import { getDateValue } from "../utils/getDateValue";
 import { getDateDisplay } from "../utils/getDateDisplay";
@@ -13,53 +14,35 @@ const dateValue = getDateValue(date);
 
 <article class="group relative flex flex-col">
   <time
-    class="relative z-10 mb-3 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500"
+    class="font-editorial-mono relative z-10 mb-2 text-[0.72rem] uppercase tracking-[0.18em]"
+    style="color: var(--page-faint);"
     datetime={dateValue}
     transition:name={`${TRANSITION_NAMES.blogTime}-${slug}`}
+    transition:animate={fade({ duration: 180 })}
   >
-    <span class="absolute inset-y-0 left-0 flex items-center">
-      <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"> </span>
-    </span>
     {dateDisplay}
   </time>
   <a
     href={`/posts/${slug}/`}
-    class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6 sm:rounded-2xl"
+    class="absolute -inset-x-2 -inset-y-3 z-20 text-[0px]"
     >{title}</a
   >
   <h2
-    class="text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100"
+    class="relative z-10 text-[1.18rem] font-semibold leading-8 tracking-tight"
+    style="color: var(--page-heading);"
     transition:name={`${TRANSITION_NAMES.blogTitle}-${slug}`}
+    transition:animate={fade({ duration: 220 })}
   >
-    <div
-      class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl"
-    >
-    </div>
-    <span>
-      <span></span>
-      <span class="relative z-10">{title}</span>
-    </span>
+    <span class="relative z-10">{title}</span>
   </h2>
-  <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+  <p class="relative z-10 mt-2 text-[0.98rem] leading-7" style="color: var(--page-muted);">
     {subtitle}
   </p>
   <div
-    class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500"
+    class="font-editorial-sans relative z-10 mt-3 flex items-center gap-2 text-[0.74rem] font-medium uppercase tracking-[0.16em]"
+    style="color: var(--page-link);"
   >
     Read article
-    <svg
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true"
-      class="ml-1 h-4 w-4 stroke-current"
-    >
-      <path
-        d="M6.75 5.75 9.25 8l-2.5 2.25"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-      </path>
-    </svg>
+    <span aria-hidden="true">→</span>
   </div>
 </article>

--- a/daniakash.com/src/components/ArticleContainer.astro
+++ b/daniakash.com/src/components/ArticleContainer.astro
@@ -11,7 +11,8 @@ import ArrowLeftIcon from "../pages/components/icons/ArrowLeftIcon.astro";
             role="button"
             onclick="history.back()"
             aria-label="Go back to articles"
-            class="group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 transition dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20 lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0"
+            class="group mb-8 flex h-10 w-10 items-center justify-center border transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0"
+            style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 78%, transparent);"
             ><ArrowLeftIcon /></button
           >
           <slot />

--- a/daniakash.com/src/components/ArticleContainer.astro
+++ b/daniakash.com/src/components/ArticleContainer.astro
@@ -2,7 +2,7 @@
 import ArrowLeftIcon from "../pages/components/icons/ArrowLeftIcon.astro";
 ---
 
-<div class="mt-16 sm:mt-32">
+<div class="mt-20 sm:mt-36">
   <div class="relative px-4 sm:px-8 lg:px-12">
     <div class="mx-auto max-w-2xl lg:max-w-5xl">
       <div class="xl:relative">
@@ -11,7 +11,7 @@ import ArrowLeftIcon from "../pages/components/icons/ArrowLeftIcon.astro";
             role="button"
             onclick="history.back()"
             aria-label="Go back to articles"
-            class="group mb-8 flex h-10 w-10 items-center justify-center border transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0"
+            class="group mb-10 flex h-10 w-10 items-center justify-center border transition lg:absolute lg:-left-6 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0"
             style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 78%, transparent);"
             ><ArrowLeftIcon /></button
           >

--- a/daniakash.com/src/components/BlogArticle.astro
+++ b/daniakash.com/src/components/BlogArticle.astro
@@ -15,7 +15,7 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
   <div class="group relative flex flex-col items-start md:col-span-3">
     <a
       href={`/posts/${slug}/`}
-      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6 sm:rounded-2xl"
+      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6"
       >{post.title}</a
     >
     <h2
@@ -23,7 +23,8 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
       transition:name={`${TRANSITION_NAMES.blogTitle}-${slug}`}
     >
       <div
-        class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl"
+        class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+        style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
       >
       </div>
       <span>

--- a/daniakash.com/src/components/BlogArticle.astro
+++ b/daniakash.com/src/components/BlogArticle.astro
@@ -15,7 +15,7 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
   <div class="group relative flex flex-col items-start md:col-span-3">
     <a
       href={`/posts/${slug}/`}
-      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6"
+      class="absolute -inset-x-4 -inset-y-7 z-20 text-[0px] sm:-inset-x-6"
       >{post.title}</a
     >
     <h2
@@ -23,7 +23,7 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
       transition:name={`${TRANSITION_NAMES.blogTitle}-${slug}`}
     >
       <div
-        class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+        class="absolute -inset-x-4 -inset-y-7 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
         style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
       >
       </div>
@@ -33,7 +33,7 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
       </span>
     </h2>
     <time
-      class="relative z-10 order-first mb-3 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500 md:hidden"
+      class="relative z-10 order-first mb-4 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500 md:hidden"
       datetime={dateValue}
     >
       <span
@@ -45,11 +45,11 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
       </span>
       {dateDisplay}
     </time>
-    <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+    <p class="relative z-10 mt-3 max-w-2xl text-sm leading-7 text-zinc-600 dark:text-zinc-400">
       {post.subtitle}
     </p>
     <div
-      class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500"
+      class="relative z-10 mt-5 flex items-center text-sm font-medium text-teal-500"
     >
       Read article
       <svg
@@ -67,7 +67,7 @@ const { post, dateValue, dateDisplay, slug } = Astro.props;
     </div>
   </div>
   <time
-    class="relative z-10 order-first mb-3 mt-1 flex hidden items-center text-sm text-zinc-400 dark:text-zinc-500 md:block"
+    class="relative z-10 order-first mb-4 mt-1 hidden items-center text-sm text-zinc-400 dark:text-zinc-500 md:block"
     datetime={dateValue}
     transition:name={`${TRANSITION_NAMES.blogTime}-${slug}`}
   >

--- a/daniakash.com/src/components/NewsLetterArticle.astro
+++ b/daniakash.com/src/components/NewsLetterArticle.astro
@@ -14,7 +14,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
   <div class="group relative flex flex-col items-start md:col-span-3">
     <a
       href={`/newsletter/${slug}/`}
-      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6 sm:rounded-2xl"
+      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6"
       >{title}</a
     >
     <h2
@@ -22,7 +22,8 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
       transition:name={`${TRANSITION_NAMES.newsletterTitle}-${slug}`}
     >
       <div
-        class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl"
+        class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+        style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
       >
       </div>
       <span>

--- a/daniakash.com/src/components/NewsLetterArticle.astro
+++ b/daniakash.com/src/components/NewsLetterArticle.astro
@@ -14,7 +14,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
   <div class="group relative flex flex-col items-start md:col-span-3">
     <a
       href={`/newsletter/${slug}/`}
-      class="absolute -inset-x-4 -inset-y-6 z-20 text-[0px] sm:-inset-x-6"
+      class="absolute -inset-x-4 -inset-y-7 z-20 text-[0px] sm:-inset-x-6"
       >{title}</a
     >
     <h2
@@ -22,7 +22,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
       transition:name={`${TRANSITION_NAMES.newsletterTitle}-${slug}`}
     >
       <div
-        class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+        class="absolute -inset-x-4 -inset-y-7 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
         style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
       >
       </div>
@@ -32,7 +32,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
       </span>
     </h2>
     <time
-      class="relative z-10 order-first mb-3 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500 md:hidden"
+      class="relative z-10 order-first mb-4 flex items-center pl-3.5 text-sm text-zinc-400 dark:text-zinc-500 md:hidden"
       datetime={dateValue}
     >
       <span
@@ -45,7 +45,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
       {dateDisplay}
     </time>
     <div
-      class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500"
+      class="relative z-10 mt-5 flex items-center text-sm font-medium text-teal-500"
     >
       Read article
       <svg
@@ -63,7 +63,7 @@ const { title, dateValue, dateDisplay, slug } = Astro.props;
     </div>
   </div>
   <time
-    class="relative z-10 order-first mb-3 mt-1 flex hidden items-center text-sm text-zinc-400 dark:text-zinc-500 md:block"
+    class="relative z-10 order-first mb-4 mt-1 hidden items-center text-sm text-zinc-400 dark:text-zinc-500 md:block"
     datetime={dateValue}
     transition:name={`${TRANSITION_NAMES.newsletterTime}-${slug}`}
   >

--- a/daniakash.com/src/components/Newsletter.astro
+++ b/daniakash.com/src/components/Newsletter.astro
@@ -8,15 +8,16 @@ import MailIcon from "./icons/MailIcon.astro";
   method="post"
   target="popupwindow"
   onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-  class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40"
+  class="border p-5 sm:p-6"
+  style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
   transition:name={TRANSITION_NAMES.newsletterForm}
 >
-  <h2 class="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+  <h2 class="flex items-center text-sm font-semibold" style="color: var(--page-heading);">
     <MailIcon class="h-6 w-6 flex-none" />
     <span class="ml-3">Stay up to date</span>
   </h2>
-  <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-    Get notified when I publish something new, and unsubscribe at any time.
+  <p class="mt-3 text-sm leading-7" style="color: var(--page-muted);">
+    Short notes when I publish something new. No feed spam, no busywork.
   </p>
   <div class="mt-6 flex">
     <input
@@ -26,10 +27,12 @@ import MailIcon from "./icons/MailIcon.astro";
       placeholder="Email address"
       aria-label="Email address"
       required
-      class="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(theme(spacing.2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-500/10 dark:border-zinc-700 dark:bg-zinc-700/[0.15] dark:text-zinc-200 dark:placeholder:text-zinc-500 dark:focus:border-teal-400 dark:focus:ring-teal-400/10 sm:text-sm"
+      class="min-w-0 flex-auto appearance-none border px-3 py-2 shadow-none focus:outline-none sm:text-sm"
+      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 92%, transparent); color: var(--page-text);"
     />
     <button
-      class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md bg-zinc-800 px-3 py-2 text-sm font-semibold text-zinc-100 outline-offset-2 transition hover:bg-zinc-700 active:bg-zinc-800 active:text-zinc-100/70 active:transition-none dark:bg-zinc-700 dark:hover:bg-zinc-600 dark:active:bg-zinc-700 dark:active:text-zinc-100/70"
+      class="font-editorial-sans ml-3 inline-flex flex-none items-center justify-center gap-2 border px-4 py-2 text-[0.72rem] font-semibold uppercase tracking-[0.16em] outline-offset-2 transition"
+      style="border-color: var(--page-heading); background-color: var(--page-heading); color: var(--page-bg);"
       type="submit">Join</button
     >
   </div>

--- a/daniakash.com/src/components/Newsletter.astro
+++ b/daniakash.com/src/components/Newsletter.astro
@@ -8,7 +8,7 @@ import MailIcon from "./icons/MailIcon.astro";
   method="post"
   target="popupwindow"
   onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-  class="border p-5 sm:p-6"
+  class="border p-6 sm:p-7"
   style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
   transition:name={TRANSITION_NAMES.newsletterForm}
 >
@@ -16,10 +16,10 @@ import MailIcon from "./icons/MailIcon.astro";
     <MailIcon class="h-6 w-6 flex-none" />
     <span class="ml-3">Stay up to date</span>
   </h2>
-  <p class="mt-3 text-sm leading-7" style="color: var(--page-muted);">
+  <p class="mt-4 text-sm leading-7" style="color: var(--page-muted);">
     Short notes when I publish something new. No feed spam, no busywork.
   </p>
-  <div class="mt-6 flex">
+  <div class="mt-7 flex">
     <input
       type="email"
       name="email"

--- a/daniakash.com/src/layouts/ContentArea.astro
+++ b/daniakash.com/src/layouts/ContentArea.astro
@@ -1,6 +1,5 @@
 ---
 ---
----
 <div class="pointer-events-none fixed inset-0 flex justify-center px-4 sm:px-6">
   <div class="w-full max-w-5xl">
     <div

--- a/daniakash.com/src/layouts/ContentArea.astro
+++ b/daniakash.com/src/layouts/ContentArea.astro
@@ -1,7 +1,6 @@
 ---
 ---
 ---
-
 <div class="pointer-events-none fixed inset-0 flex justify-center px-4 sm:px-6">
   <div class="w-full max-w-5xl">
     <div

--- a/daniakash.com/src/layouts/ContentArea.astro
+++ b/daniakash.com/src/layouts/ContentArea.astro
@@ -1,11 +1,14 @@
 ---
-
+---
 ---
 
-<div class="fixed inset-0 flex justify-center md:px-8">
-  <div class="flex w-full max-w-7xl lg:px-8">
+<div class="pointer-events-none fixed inset-0 flex justify-center px-4 sm:px-6">
+  <div class="w-full max-w-5xl">
     <div
-      class="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20"
+      class="h-full border-x"
+      style={`background:
+        linear-gradient(to bottom, color-mix(in srgb, var(--page-panel) 92%, transparent), color-mix(in srgb, var(--page-panel) 78%, transparent));
+        border-color: var(--page-border);`}
     >
     </div>
   </div>

--- a/daniakash.com/src/layouts/ContentArea.astro
+++ b/daniakash.com/src/layouts/ContentArea.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <div class="pointer-events-none fixed inset-0 flex justify-center px-4 sm:px-6">
-  <div class="w-full max-w-5xl">
+  <div class="w-full max-w-6xl">
     <div
       class="h-full border-x"
       style={`background:

--- a/daniakash.com/src/layouts/Header.astro
+++ b/daniakash.com/src/layouts/Header.astro
@@ -5,8 +5,8 @@ import DarkModeToggle from "../pages/components/DarkModeToggle.astro";
 import Nav from "../pages/components/nav.astro";
 ---
 
-<header class="relative m-auto flex w-full max-w-7xl flex-none flex-col">
-  <div class="flex items-center justify-between gap-4 border-b py-5 sm:py-6" style="border-color: var(--page-border);">
+<header class="relative m-auto flex w-full flex-none flex-col">
+  <div class="flex items-center justify-between gap-4 border-b py-6 sm:py-7" style="border-color: var(--page-border);">
     <div class="flex min-w-0 items-center gap-3">
       <Avatar isHomePage={false} />
       <div class="hidden min-w-0 sm:block">

--- a/daniakash.com/src/layouts/Header.astro
+++ b/daniakash.com/src/layouts/Header.astro
@@ -1,34 +1,31 @@
 ---
+import { fade } from "astro:transitions";
 import Avatar from "../pages/components/Avatar.astro";
 import DarkModeToggle from "../pages/components/DarkModeToggle.astro";
 import Nav from "../pages/components/nav.astro";
-
-interface Props {
-  isHomePage?: boolean;
-}
-
-const { isHomePage = false } = Astro.props;
 ---
 
 <header class="relative m-auto flex w-full max-w-7xl flex-none flex-col">
-  <div
-    class={isHomePage
-      ? "mr-[calc(theme(spacing.4)+48px)] mt-6 flex flex-row self-end sm:px-8 md:mr-[unset] md:self-center"
-      : "flex justify-between mt-6 items-center"}
-  >
-    {!isHomePage && <Avatar isHomePage={isHomePage} />}
-    <div>
-      <Nav />
+  <div class="flex items-center justify-between gap-4 border-b py-5 sm:py-6" style="border-color: var(--page-border);">
+    <div class="flex min-w-0 items-center gap-3">
+      <Avatar isHomePage={false} />
+      <div class="hidden min-w-0 sm:block">
+        <a
+          href="/"
+          class="font-editorial-sans text-sm font-medium tracking-[0.12em] uppercase"
+          style="color: var(--page-heading);"
+          transition:animate={fade({ duration: 180 })}
+        >
+          Dani Akash
+        </a>
+        <p class="font-editorial-mono text-[0.68rem] tracking-[0.2em] uppercase" style="color: var(--page-faint);">
+          Writer / Speaker / Hacker
+        </p>
+      </div>
     </div>
-    {!isHomePage && <div class="w-10" />}
-  </div>
-  {
-    isHomePage && (
-      <div class="mt-[calc(theme(spacing.16)-theme(spacing.3))]" />
-      <Avatar isHomePage={isHomePage} />
-    )
-  }
-  <div class="absolute right-0 top-6">
-    <DarkModeToggle />
+    <div class="flex items-center gap-3">
+      <Nav />
+      <DarkModeToggle />
+    </div>
   </div>
 </header>

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -1,7 +1,6 @@
 ---
 import "../styles/global.css";
 import Footer from "../pages/components/Footer.astro";
-import HeroImages from "../pages/components/HeroImages.astro";
 import ContentArea from "./ContentArea.astro";
 import Header from "./Header.astro";
 import { ClientRouter } from "astro:transitions";
@@ -142,23 +141,14 @@ const ogImage = image || fallbackImage;
   </head>
   <body class="flex h-full w-full overflow-x-hidden bg-zinc-50 dark:bg-black">
     <ContentArea />
-    <div
-      class="relative m-auto flex w-full max-w-7xl flex-col overflow-visible md:px-8 lg:px-16"
-    >
-      <div class="px-4 md:px-8 lg:px-12">
+    <div class="relative m-auto flex w-full max-w-5xl flex-col overflow-visible">
+      <div class="px-4 sm:px-6 lg:px-10">
         <Header isHomePage={isHomePage} />
         <main><slot /></main>
-        <div class="mt-40">
+        <div class="mt-28 sm:mt-36">
           <Footer />
         </div>
       </div>
-      {
-        isHomePage && (
-          <div class="z-100 absolute top-[36rem] hidden w-screen overflow-clip mobile:block sm:block md:left-[-1rem] md:top-[30rem] md:w-[calc(100vw+1rem)] lg:left-[-8rem] lg:top-[28rem] lg:w-[calc(100vw+8rem)] lg:py-16 xl:left-[-16rem] xl:w-[calc(100vw+16rem)] xl:pl-28">
-            <HeroImages />
-          </div>
-        )
-      }
     </div>
   </body>
 </html>

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -141,8 +141,8 @@ const ogImage = image || fallbackImage;
   </head>
   <body class="flex h-full w-full overflow-x-hidden bg-zinc-50 dark:bg-black">
     <ContentArea />
-    <div class="relative m-auto flex w-full max-w-5xl flex-col overflow-visible">
-      <div class="px-4 sm:px-6 lg:px-10">
+    <div class="relative m-auto flex w-full max-w-6xl flex-col overflow-visible">
+      <div class="px-4 sm:px-6 lg:px-12">
         <Header isHomePage={isHomePage} />
         <main><slot /></main>
         <div class="mt-28 sm:mt-36">

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -19,10 +19,10 @@ const social = (await getCollection("social"))[0]!;
 
 <MainLayout title="About">
   <div
-    class="mt-16 grid grid-cols-1 gap-y-16 lg:grid-cols-2 lg:grid-rows-[auto_1fr]"
+    class="mt-20 grid grid-cols-1 gap-x-18 gap-y-20 lg:grid-cols-[minmax(0,1.15fr)_22rem] lg:grid-rows-[auto_1fr] sm:mt-24 sm:gap-y-24"
   >
-    <div class="lg:pl-20">
-      <div class="max-w-xs px-2.5 lg:max-w-none">
+    <div class="lg:pl-8">
+      <div class="max-w-sm px-2.5 lg:max-w-none">
         <Image
           src={`${ASSET_PREFIX}/image-3.jpg`}
           alt="about-image"
@@ -44,12 +44,12 @@ const social = (await getCollection("social"))[0]!;
       >
         I’m Dani Akash
       </h1>
-      <div class="prose mt-6 space-y-7 dark:prose-invert">
+      <div class="prose mt-10 max-w-3xl space-y-9 dark:prose-invert">
         <Content />
       </div>
     </div>
 
-    <div class="lg:pl-20">
+    <div class="lg:pl-8">
       <ul role="list">
         <li class="flex">
           <a
@@ -60,7 +60,7 @@ const social = (await getCollection("social"))[0]!;
             ><BlueskyIcon /><span class="ml-4">Follow on Bluesky</span></a
           >
         </li>
-        <li class="mt-4 flex">
+        <li class="mt-5 flex">
           <a
             href={social.data.twitter}
             class="group flex text-sm font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"
@@ -69,7 +69,7 @@ const social = (await getCollection("social"))[0]!;
             ><TwitterIcon /><span class="ml-4">Follow on X</span></a
           >
         </li>
-        <li class="mt-4 flex">
+        <li class="mt-5 flex">
           <a
             href={social.data.instagram}
             class="group flex text-sm font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"
@@ -77,7 +77,7 @@ const social = (await getCollection("social"))[0]!;
             rel="noopener"
             ><InstagramIcon /><span class="ml-4">Follow on Instagram</span></a
           >
-        </li><li class="mt-4 flex">
+        </li><li class="mt-5 flex">
           <a
             href={social.data.github}
             class="group flex text-sm font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"
@@ -85,7 +85,7 @@ const social = (await getCollection("social"))[0]!;
             rel="noopener"
             ><GithubIcon /><span class="ml-4">Follow on GitHub</span></a
           >
-        </li><li class="mt-4 flex">
+        </li><li class="mt-5 flex">
           <a
             href={social.data.linkedIn}
             class="group flex text-sm font-medium text-zinc-800 transition hover:text-teal-500 dark:text-zinc-200 dark:hover:text-teal-500"
@@ -94,7 +94,7 @@ const social = (await getCollection("social"))[0]!;
             ><LinkedinIcon /><span class="ml-4">Follow on LinkedIn</span></a
           >
         </li><li
-          class="mt-8 flex border-t border-zinc-100 pt-8 dark:border-zinc-700/40"
+          class="mt-10 flex border-t border-zinc-100 pt-10 dark:border-zinc-700/40"
         >
           <a
             href={`mailto:${social.data.email}`}

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
+import { fade } from "astro:transitions";
 import { TRANSITION_NAMES } from "../constants/transition-names";
 import MainLayout from "../layouts/MainLayout.astro";
 import { ASSET_PREFIX } from "../constants/asset-prefix";
@@ -39,6 +40,7 @@ const social = (await getCollection("social"))[0]!;
       <h1
         class="text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl"
         transition:name={TRANSITION_NAMES.heroTitle}
+        transition:animate={fade({ duration: 240 })}
       >
         I’m Dani Akash
       </h1>

--- a/daniakash.com/src/pages/blog.astro
+++ b/daniakash.com/src/pages/blog.astro
@@ -19,11 +19,9 @@ const posts = (await getCollection("blog")).sort((a, b) => {
       title="The Blog Zone"
       subtitle="Where my thoughts get some air time (and occasionally make sense)."
     />
-    <div class="mt-16 sm:mt-20">
-      <div
-        class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40"
-      >
-        <div class="flex max-w-3xl flex-col space-y-16">
+    <div class="mt-20 sm:mt-24">
+      <div>
+        <div class="flex max-w-4xl flex-col space-y-20">
           {
             posts.map((post) => {
               const dateValue = getDateValue(post.data.date);

--- a/daniakash.com/src/pages/components/Avatar.astro
+++ b/daniakash.com/src/pages/components/Avatar.astro
@@ -1,5 +1,6 @@
 ---
 import { Image } from "astro:assets";
+import { fade } from "astro:transitions";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
 import { ASSET_PREFIX } from "../../constants/asset-prefix";
 
@@ -16,10 +17,13 @@ const { isHomePage = false } = Astro.props;
     height={96}
     width={96}
     transition:name={TRANSITION_NAMES.avatar}
+    transition:animate={fade({ duration: 220 })}
     alt="dani-akash"
-    class={`rounded-full bg-zinc-100 object-cover dark:bg-zinc-800 hover:transition-all hover:-translate-y-1 hover:scale-110 hover:shadow-teal-500 hover:shadow-2xl hover:dark:shadow-teal-400 ${
-      isHomePage ? "h-16 w-16" : "h-9 w-9"
+    class={`rounded-full border object-cover transition-transform duration-200 hover:-translate-y-0.5 ${
+      isHomePage ? "h-12 w-12" : "h-10 w-10"
     }`}
+    style={`background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);
+      border-color: var(--page-strong-border);`}
     src={`${ASSET_PREFIX}/avatar.jpg`}
   />
 </a>

--- a/daniakash.com/src/pages/components/ContentContainer.astro
+++ b/daniakash.com/src/pages/components/ContentContainer.astro
@@ -7,6 +7,6 @@
 //   })}
 ---
 
-<div class="mt-16 sm:mt-32">
+<div class="mt-20 sm:mt-36">
   <slot />
 </div>

--- a/daniakash.com/src/pages/components/DarkModeToggle.astro
+++ b/daniakash.com/src/pages/components/DarkModeToggle.astro
@@ -6,7 +6,7 @@ import { TRANSITION_NAMES } from "../../constants/transition-names";
 <button
   aria-label="dark mode toggle"
   id="dev-theme-mode-toggle"
-  class="group rounded-full border px-3 py-2 transition"
+  class="group border px-3 py-2 transition"
   style="background-color: color-mix(in srgb, var(--page-panel) 78%, transparent); border-color: var(--page-border);"
   transition:name={TRANSITION_NAMES.darkModeToggle}
   transition:animate={fade({ duration: 500 })}

--- a/daniakash.com/src/pages/components/DarkModeToggle.astro
+++ b/daniakash.com/src/pages/components/DarkModeToggle.astro
@@ -6,7 +6,8 @@ import { TRANSITION_NAMES } from "../../constants/transition-names";
 <button
   aria-label="dark mode toggle"
   id="dev-theme-mode-toggle"
-  class="group rounded-full bg-white/90 px-3 py-2 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20"
+  class="group rounded-full border px-3 py-2 transition"
+  style="background-color: color-mix(in srgb, var(--page-panel) 78%, transparent); border-color: var(--page-border);"
   transition:name={TRANSITION_NAMES.darkModeToggle}
   transition:animate={fade({ duration: 500 })}
 >

--- a/daniakash.com/src/pages/components/Footer.astro
+++ b/daniakash.com/src/pages/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import { navLinks } from "../../constants/navLinks";
+import { fade } from "astro:transitions";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
 
 const currentPath = Astro.url.pathname;
@@ -7,11 +8,14 @@ const currentYear = new Date().getFullYear();
 ---
 
 <div
-  class="flex flex-col items-center justify-between gap-y-6 border-t border-zinc-100 px-4 pb-16 pt-10 dark:border-zinc-700/40 sm:flex-row"
+  class="flex flex-col gap-6 border-t pb-14 pt-8 sm:flex-row sm:items-center sm:justify-between"
+  style="border-color: var(--page-border);"
   transition:name={TRANSITION_NAMES.footer}
+  transition:animate={fade({ duration: 180 })}
 >
   <div
-    class="flex w-full flex-wrap justify-center gap-6 text-sm font-medium text-zinc-800 dark:text-zinc-200 md:w-[unset] md:justify-start"
+    class="font-editorial-sans flex w-full flex-wrap gap-x-5 gap-y-2 text-[0.72rem] font-medium uppercase tracking-[0.16em] md:w-[unset]"
+    style="color: var(--page-muted);"
   >
     {
       navLinks.map((link) => {
@@ -20,9 +24,7 @@ const currentYear = new Date().getFullYear();
         return (
           <a
             href={link.href}
-            class={`hover:text-teal-500 dark:hover:text-teal-400 ${
-              isActive && "text-teal-500 dark:text-teal-400"
-            }`}
+            style={isActive ? "color: var(--page-heading);" : undefined}
           >
             {link.title}
           </a>
@@ -30,13 +32,14 @@ const currentYear = new Date().getFullYear();
       })
     }
   </div>
-  <p class="text-sm text-zinc-500 dark:text-zinc-400">
+  <p class="text-sm leading-7" style="color: var(--page-muted);">
     &#169;<!-- -->
     <span id="footer-year">{currentYear}</span><!-- -->
     <a
       href="https://github.com/daniakash/daniakash"
       target="_blank"
-      class="font-calorie text-2xl underline hover:text-teal-500 dark:hover:text-teal-400"
+      class="font-calorie ml-1 text-2xl underline"
+      style="color: var(--page-heading);"
       rel="noopener">Dani Akash.</a
     > All rights reserved.
   </p>

--- a/daniakash.com/src/pages/components/Header.astro
+++ b/daniakash.com/src/pages/components/Header.astro
@@ -15,7 +15,7 @@ const { title, subtitle } = Astro.props;
     transition:name={TRANSITION_NAMES.heroTitle}
   >
     {title}
-  </h1><p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">
+  </h1><p class="mt-7 max-w-xl text-[0.98rem] leading-8 text-zinc-600 dark:text-zinc-400">
     {subtitle}<slot />
   </p>
 </header>

--- a/daniakash.com/src/pages/components/Hero.astro
+++ b/daniakash.com/src/pages/components/Hero.astro
@@ -34,12 +34,12 @@ const social = (await getCollection("social"))[0]!;
     </p>
     <p style="color: var(--page-muted);">
       This site is a quieter index of what I’m making:
-      <a href="/blog/" style="color: var(--page-link);"> writing</a>,
-      <a href="/newsletter/" style="color: var(--page-link);"> newsletters</a>,
-      <a href="/projects/" style="color: var(--page-link);"> projects</a>,
-      <a href="/speaking/" style="color: var(--page-link);"> talks</a>, and a
+      <a href="/blog/" class="page-inline-link"> writing</a>,
+      <a href="/newsletter/" class="page-inline-link"> newsletters</a>,
+      <a href="/projects/" class="page-inline-link"> projects</a>,
+      <a href="/speaking/" class="page-inline-link"> talks</a>, and a
       living
-      <a href="/now/" style="color: var(--page-link);"> now page</a>.
+      <a href="/now/" class="page-inline-link"> now page</a>.
     </p>
   </div>
   <div class="mt-8 flex flex-wrap gap-3 text-sm">
@@ -47,8 +47,7 @@ const social = (await getCollection("social"))[0]!;
       href={social.data.github}
       target="_blank"
       rel="noopener"
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <GithubIcon />
       <span>GitHub</span>
@@ -57,8 +56,7 @@ const social = (await getCollection("social"))[0]!;
       href={social.data.linkedIn}
       target="_blank"
       rel="noopener"
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <LinkedinIcon />
       <span>LinkedIn</span>
@@ -67,8 +65,7 @@ const social = (await getCollection("social"))[0]!;
       href={social.data.bluesky}
       target="_blank"
       rel="noopener"
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <BlueskyIcon />
       <span>Bluesky</span>
@@ -77,8 +74,7 @@ const social = (await getCollection("social"))[0]!;
       href={social.data.twitter}
       target="_blank"
       rel="noopener"
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <TwitterIcon />
       <span>X</span>
@@ -87,16 +83,14 @@ const social = (await getCollection("social"))[0]!;
       href={social.data.instagram}
       target="_blank"
       rel="noopener"
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <InstagramIcon />
       <span>Instagram</span>
     </a>
     <a
       href={`mailto:${social.data.email}`}
-      class="group inline-flex items-center gap-2 border px-3 py-2"
-      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+      class="page-action-chip"
     >
       <MailDarkIcon />
       <span>{social.data.email}</span>
@@ -108,24 +102,21 @@ const social = (await getCollection("social"))[0]!;
   >
     <a
       href="/about/"
-      class="block border p-4"
-      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
+      class="page-action-card"
     >
       <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">About</p>
       <p class="mt-2 text-sm" style="color: var(--page-text);">Background, experience, and contact links.</p>
     </a>
     <a
       href="/resume/"
-      class="block border p-4"
-      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
+      class="page-action-card"
     >
       <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">Resume</p>
       <p class="mt-2 text-sm" style="color: var(--page-text);">Work history, roles, and the longer career timeline.</p>
     </a>
     <a
       href="/now/"
-      class="block border p-4"
-      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
+      class="page-action-card"
     >
       <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">Now</p>
       <p class="mt-2 text-sm" style="color: var(--page-text);">What I’m paying attention to right now.</p>

--- a/daniakash.com/src/pages/components/Hero.astro
+++ b/daniakash.com/src/pages/components/Hero.astro
@@ -26,7 +26,7 @@ const social = (await getCollection("social"))[0]!;
   >
     I’m Dani Akash
   </h1>
-  <div class="mt-6 max-w-2xl space-y-4 text-[0.94rem] leading-7 sm:text-[0.98rem]">
+  <div class="mt-7 max-w-2xl space-y-5 text-[0.94rem] leading-8 sm:text-[0.98rem]">
     <p style="color: var(--page-text);">
       I write about web development, build software for developers, and speak
       about frontend systems, React Native, and the weird little details that
@@ -42,7 +42,7 @@ const social = (await getCollection("social"))[0]!;
       <a href="/now/" class="page-inline-link"> now page</a>.
     </p>
   </div>
-  <div class="mt-8 flex flex-wrap gap-3 text-sm">
+  <div class="mt-10 flex flex-wrap gap-3.5 text-sm">
     <a
       href={social.data.github}
       target="_blank"
@@ -97,7 +97,7 @@ const social = (await getCollection("social"))[0]!;
     </a>
   </div>
   <div
-    class="mt-8 grid gap-4 border-t pt-6 sm:grid-cols-3"
+    class="mt-12 grid gap-5 border-t pt-8 sm:grid-cols-3"
     style="border-color: var(--page-border);"
   >
     <a

--- a/daniakash.com/src/pages/components/Hero.astro
+++ b/daniakash.com/src/pages/components/Hero.astro
@@ -1,69 +1,82 @@
 ---
 import { getCollection } from "astro:content";
+import { fade } from "astro:transitions";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
-import TypeWriter from "./TypeWriter.astro";
-import TwitterIcon from "../../components/icons/TwitterIcon.astro";
-import InstagramIcon from "../../components/icons/InstagramIcon.astro";
-import GithubIcon from "../../components/icons/GithubIcon.astro";
-import LinkedinIcon from "../../components/icons/LinkedinIcon.astro";
-import BlueskyIcon from "../../components/icons/BlueskyIcon.astro";
 const social = (await getCollection("social"))[0]!;
 ---
 
-<div class="max-w-2xl">
-  <h1
-    class="text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl"
-    transition:name={TRANSITION_NAMES.heroTitle}
+<div class="max-w-3xl">
+  <p
+    class="font-editorial-mono text-[0.7rem] font-medium uppercase tracking-[0.2em]"
+    style="color: var(--page-faint);"
   >
-    Writer, Speaker, Hacker
+    Personal site / notebook / archive
+  </p>
+  <h1
+    class="mt-4 max-w-2xl text-4xl font-semibold tracking-tight sm:text-5xl"
+    style="color: var(--page-heading);"
+    transition:name={TRANSITION_NAMES.heroTitle}
+    transition:animate={fade({ duration: 240 })}
+  >
+    I’m Dani Akash
   </h1>
-  <TypeWriter />
-  <div class="mt-6 flex gap-6">
+  <div class="mt-6 max-w-2xl space-y-4 text-[1.03rem] leading-8 sm:text-[1.08rem]">
+    <p style="color: var(--page-text);">
+      I write about web development, build software for developers, and speak
+      about frontend systems, React Native, and the weird little details that
+      make products feel sharp.
+    </p>
+    <p style="color: var(--page-muted);">
+      This site is a quieter index of what I’m making:
+      <a href="/blog/" style="color: var(--page-link);"> writing</a>,
+      <a href="/newsletter/" style="color: var(--page-link);"> newsletters</a>,
+      <a href="/projects/" style="color: var(--page-link);"> projects</a>,
+      <a href="/speaking/" style="color: var(--page-link);"> talks</a>, and a
+      living
+      <a href="/now/" style="color: var(--page-link);"> now page</a>.
+    </p>
+  </div>
+  <div class="mt-8 flex flex-wrap gap-x-5 gap-y-3 text-sm" style="color: var(--page-muted);">
+    <a href={social.data.github} target="_blank" rel="noopener" style="color: var(--page-link);">
+      GitHub
+    </a>
+    <a href={social.data.linkedIn} target="_blank" rel="noopener" style="color: var(--page-link);">
+      LinkedIn
+    </a>
+    <a href={social.data.bluesky} target="_blank" rel="noopener" style="color: var(--page-link);">
+      Bluesky
+    </a>
+    <a href={`mailto:${social.data.email}`} style="color: var(--page-link);">
+      {social.data.email}
+    </a>
+  </div>
+  <div
+    class="mt-8 grid gap-4 border-t pt-6 sm:grid-cols-3"
+    style="border-color: var(--page-border);"
+  >
     <a
-      class="bluesky-flutter group relative z-10 -m-1 -mt-[6px] inline-block p-1"
-      href={social.data.bluesky}
-      aria-label="Follow on Bluesky"
-      target="_blank"
-      rel="noopener"
+      href="/about/"
+      class="block border p-4"
+      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
     >
-      <BlueskyIcon />
+      <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">About</p>
+      <p class="mt-2 text-sm" style="color: var(--page-text);">Background, experience, and contact links.</p>
     </a>
     <a
-      role="button"
-      class="group relative z-10 -m-1 inline-block p-1"
-      href={social.data.twitter}
-      aria-label="Follow on Twitter"
-      target="_blank"
-      rel="noopener"
+      href="/resume/"
+      class="block border p-4"
+      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
     >
-      <TwitterIcon />
+      <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">Resume</p>
+      <p class="mt-2 text-sm" style="color: var(--page-text);">Work history, roles, and the longer career timeline.</p>
     </a>
     <a
-      class="group relative z-10 -m-1 inline-block p-1"
-      href={social.data.instagram}
-      aria-label="Follow on Instagram"
-      target="_blank"
-      rel="noopener"
+      href="/now/"
+      class="block border p-4"
+      style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);"
     >
-      <InstagramIcon />
-    </a>
-    <a
-      class="group relative z-10 -m-1 inline-block p-1"
-      href={social.data.github}
-      aria-label="Follow on GitHub"
-      target="_blank"
-      rel="noopener"
-    >
-      <GithubIcon />
-    </a>
-    <a
-      class="group relative z-10 -m-1 inline-block p-1"
-      href="https://www.linkedin.com/in/daniakash/"
-      aria-label="Follow on LinkedIn"
-      target="_blank"
-      rel="noopener"
-    >
-      <LinkedinIcon />
+      <p class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">Now</p>
+      <p class="mt-2 text-sm" style="color: var(--page-text);">What I’m paying attention to right now.</p>
     </a>
   </div>
 </div>

--- a/daniakash.com/src/pages/components/Hero.astro
+++ b/daniakash.com/src/pages/components/Hero.astro
@@ -26,7 +26,7 @@ const social = (await getCollection("social"))[0]!;
   >
     I’m Dani Akash
   </h1>
-  <div class="mt-6 max-w-2xl space-y-4 text-[1.03rem] leading-8 sm:text-[1.08rem]">
+  <div class="mt-6 max-w-2xl space-y-4 text-[0.94rem] leading-7 sm:text-[0.98rem]">
     <p style="color: var(--page-text);">
       I write about web development, build software for developers, and speak
       about frontend systems, React Native, and the weird little details that

--- a/daniakash.com/src/pages/components/Hero.astro
+++ b/daniakash.com/src/pages/components/Hero.astro
@@ -1,6 +1,12 @@
 ---
 import { getCollection } from "astro:content";
 import { fade } from "astro:transitions";
+import GithubIcon from "../../components/icons/GithubIcon.astro";
+import InstagramIcon from "../../components/icons/InstagramIcon.astro";
+import LinkedinIcon from "../../components/icons/LinkedinIcon.astro";
+import MailDarkIcon from "../../components/icons/MailDarkIcon.astro";
+import TwitterIcon from "../../components/icons/TwitterIcon.astro";
+import BlueskyIcon from "../../components/icons/BlueskyIcon.astro";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
 const social = (await getCollection("social"))[0]!;
 ---
@@ -36,18 +42,64 @@ const social = (await getCollection("social"))[0]!;
       <a href="/now/" style="color: var(--page-link);"> now page</a>.
     </p>
   </div>
-  <div class="mt-8 flex flex-wrap gap-x-5 gap-y-3 text-sm" style="color: var(--page-muted);">
-    <a href={social.data.github} target="_blank" rel="noopener" style="color: var(--page-link);">
-      GitHub
+  <div class="mt-8 flex flex-wrap gap-3 text-sm">
+    <a
+      href={social.data.github}
+      target="_blank"
+      rel="noopener"
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <GithubIcon />
+      <span>GitHub</span>
     </a>
-    <a href={social.data.linkedIn} target="_blank" rel="noopener" style="color: var(--page-link);">
-      LinkedIn
+    <a
+      href={social.data.linkedIn}
+      target="_blank"
+      rel="noopener"
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <LinkedinIcon />
+      <span>LinkedIn</span>
     </a>
-    <a href={social.data.bluesky} target="_blank" rel="noopener" style="color: var(--page-link);">
-      Bluesky
+    <a
+      href={social.data.bluesky}
+      target="_blank"
+      rel="noopener"
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <BlueskyIcon />
+      <span>Bluesky</span>
     </a>
-    <a href={`mailto:${social.data.email}`} style="color: var(--page-link);">
-      {social.data.email}
+    <a
+      href={social.data.twitter}
+      target="_blank"
+      rel="noopener"
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <TwitterIcon />
+      <span>X</span>
+    </a>
+    <a
+      href={social.data.instagram}
+      target="_blank"
+      rel="noopener"
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <InstagramIcon />
+      <span>Instagram</span>
+    </a>
+    <a
+      href={`mailto:${social.data.email}`}
+      class="group inline-flex items-center gap-2 border px-3 py-2"
+      style="border-color: var(--page-border); color: var(--page-link); background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);"
+    >
+      <MailDarkIcon />
+      <span>{social.data.email}</span>
     </a>
   </div>
   <div

--- a/daniakash.com/src/pages/components/HeroImages.astro
+++ b/daniakash.com/src/pages/components/HeroImages.astro
@@ -4,79 +4,82 @@ import { TRANSITION_NAMES } from "../../constants/transition-names";
 import { ASSET_PREFIX } from "../../constants/asset-prefix";
 ---
 
-<div class="flex flex-row gap-5 sm:gap-8">
-  <div
-    class="aspect-[9/10] w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 transition-all dark:bg-zinc-800 sm:w-72 sm:rounded-2xl lg:hover:relative lg:hover:z-10 lg:hover:rotate-0 lg:hover:scale-125"
-  >
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-1.jpg`}
-      width={300}
-      height={320}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="h-full w-full object-cover"
-      loading="eager"
-    />
+<section class="border-y py-8" style="border-color: var(--page-border);">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <p class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
+        Photo Log
+      </p>
+      <p class="mt-2 max-w-2xl text-sm leading-7" style="color: var(--page-muted);">
+        A few frames from the personal side of this site. Less hero banner, more
+        contact sheet.
+      </p>
+    </div>
+    <p class="font-editorial-mono text-[0.7rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+      /images/dani/archive
+    </p>
   </div>
-  <div
-    class="aspect-[9/10] w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 transition-all dark:bg-zinc-800 sm:w-72 sm:rounded-2xl lg:hover:relative lg:hover:z-10 lg:hover:rotate-0 lg:hover:scale-125"
-  >
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-2.jpg`}
-      width={450}
-      height={470}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="h-full w-full object-cover"
-      loading="eager"
-    />
+
+  <div class="mt-8 grid gap-5 md:grid-cols-12">
+    <figure class="md:col-span-4">
+      <div class="overflow-hidden border" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);">
+        <Image
+          alt="Dani portrait photograph"
+          src={`${ASSET_PREFIX}/image-1.jpg`}
+          width={300}
+          height={320}
+          sizes="(min-width: 768px) 28vw, 100vw"
+          class="aspect-[4/5] h-full w-full object-cover"
+          loading="eager"
+        />
+      </div>
+      <figcaption class="mt-3 flex items-center justify-between gap-3">
+        <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+          frame_01
+        </span>
+        <span class="text-sm" style="color: var(--page-muted);">homepage portrait</span>
+      </figcaption>
+    </figure>
+
+    <figure class="md:col-span-4">
+      <div class="overflow-hidden border" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);">
+        <Image
+          alt="Dani lifestyle photograph"
+          src={`${ASSET_PREFIX}/image-3.jpg`}
+          width={300}
+          height={320}
+          sizes="(min-width: 768px) 28vw, 100vw"
+          class="aspect-[4/5] h-full w-full object-cover"
+          loading="eager"
+          transition:name={TRANSITION_NAMES.heroImage}
+        />
+      </div>
+      <figcaption class="mt-3 flex items-center justify-between gap-3">
+        <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+          frame_02
+        </span>
+        <span class="text-sm" style="color: var(--page-muted);">about-page bridge image</span>
+      </figcaption>
+    </figure>
+
+    <figure class="md:col-span-4">
+      <div class="overflow-hidden border" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);">
+        <Image
+          alt="Dani portrait photograph"
+          src={`${ASSET_PREFIX}/image-5.jpg`}
+          width={300}
+          height={320}
+          sizes="(min-width: 768px) 28vw, 100vw"
+          class="aspect-[4/5] h-full w-full object-cover"
+          loading="eager"
+        />
+      </div>
+      <figcaption class="mt-3 flex items-center justify-between gap-3">
+        <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+          frame_03
+        </span>
+        <span class="text-sm" style="color: var(--page-muted);">personal notes section</span>
+      </figcaption>
+    </figure>
   </div>
-  <div
-    class="aspect-[9/10] w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 transition-all dark:bg-zinc-800 sm:w-72 sm:rounded-2xl lg:hover:relative lg:hover:z-10 lg:hover:rotate-0 lg:hover:scale-125"
-  >
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-3.jpg`}
-      width={300}
-      height={320}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="h-full w-full object-cover"
-      loading="eager"
-    />
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-3.jpg`}
-      width={300}
-      height={320}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="fixed left-0 top-0 h-full w-full object-cover"
-      transition:name={TRANSITION_NAMES.heroImage}
-    />
-  </div>
-  <div
-    class="aspect-[9/10] w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 transition-all dark:bg-zinc-800 sm:w-72 sm:rounded-2xl lg:hover:relative lg:hover:z-10 lg:hover:rotate-0 lg:hover:scale-125"
-  >
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-4.jpg`}
-      width={300}
-      height={320}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="h-full w-full object-cover"
-      loading="eager"
-    />
-  </div>
-  <div
-    class="aspect-[9/10] w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 transition-all dark:bg-zinc-800 sm:w-72 sm:rounded-2xl lg:hover:relative lg:hover:z-10 lg:hover:rotate-0 lg:hover:scale-125"
-  >
-    <Image
-      alt="dani-akash"
-      src={`${ASSET_PREFIX}/image-5.jpg`}
-      width={300}
-      height={320}
-      sizes="(min-width: 640px) 18rem, 11rem"
-      class="h-full w-full object-cover"
-      loading="eager"
-    />
-  </div>
-</div>
+</section>

--- a/daniakash.com/src/pages/components/HeroImages.astro
+++ b/daniakash.com/src/pages/components/HeroImages.astro
@@ -4,24 +4,24 @@ import { TRANSITION_NAMES } from "../../constants/transition-names";
 import { ASSET_PREFIX } from "../../constants/asset-prefix";
 ---
 
-<section class="border-y py-8" style="border-color: var(--page-border);">
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+<section class="border-t py-10 sm:py-12" style="border-color: var(--page-border);">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
     <div>
       <p class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
         Photo Log
       </p>
-      <p class="mt-2 max-w-2xl text-sm leading-7" style="color: var(--page-muted);">
+      <p class="mt-3 max-w-2xl text-sm leading-8" style="color: var(--page-muted);">
         A few frames from the personal side of this site. Less hero banner, more
         contact sheet.
       </p>
     </div>
-    <p class="font-editorial-mono text-[0.7rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
-      /images/dani/archive
+    <p class="font-editorial-mono whitespace-nowrap text-[0.7rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+      /images/dani
     </p>
   </div>
 
-  <div class="mt-8 grid gap-5 md:grid-cols-12">
-    <figure class="md:col-span-4">
+  <div class="mt-10 grid gap-6 md:grid-cols-12">
+    <figure class="hidden md:col-span-4 md:block">
       <div class="overflow-hidden border" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);">
         <Image
           alt="Dani portrait photograph"
@@ -33,11 +33,10 @@ import { ASSET_PREFIX } from "../../constants/asset-prefix";
           loading="eager"
         />
       </div>
-      <figcaption class="mt-3 flex items-center justify-between gap-3">
+      <figcaption class="mt-4 flex items-center justify-between gap-3">
         <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
           frame_01
         </span>
-        <span class="text-sm" style="color: var(--page-muted);">homepage portrait</span>
       </figcaption>
     </figure>
 
@@ -54,15 +53,14 @@ import { ASSET_PREFIX } from "../../constants/asset-prefix";
           transition:name={TRANSITION_NAMES.heroImage}
         />
       </div>
-      <figcaption class="mt-3 flex items-center justify-between gap-3">
+      <figcaption class="mt-4 flex items-center justify-between gap-3">
         <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
           frame_02
         </span>
-        <span class="text-sm" style="color: var(--page-muted);">about-page bridge image</span>
       </figcaption>
     </figure>
 
-    <figure class="md:col-span-4">
+    <figure class="hidden md:col-span-4 md:block">
       <div class="overflow-hidden border" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 70%, transparent);">
         <Image
           alt="Dani portrait photograph"
@@ -74,11 +72,10 @@ import { ASSET_PREFIX } from "../../constants/asset-prefix";
           loading="eager"
         />
       </div>
-      <figcaption class="mt-3 flex items-center justify-between gap-3">
+      <figcaption class="mt-4 flex items-center justify-between gap-3">
         <span class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
           frame_03
         </span>
-        <span class="text-sm" style="color: var(--page-muted);">personal notes section</span>
       </figcaption>
     </figure>
   </div>

--- a/daniakash.com/src/pages/components/nav.astro
+++ b/daniakash.com/src/pages/components/nav.astro
@@ -7,7 +7,8 @@ const currentPath = Astro.url.pathname;
 
 <nav class="hidden md:block">
   <ul
-    class="flex items-center justify-center rounded-full bg-white/90 px-3 py-2 text-sm font-medium text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+    class="font-editorial-sans flex items-center gap-4 text-[0.72rem] font-medium uppercase tracking-[0.16em]"
+    style="color: var(--page-muted);"
   >
     {
       navLinks.map((link) => {
@@ -17,15 +18,17 @@ const currentPath = Astro.url.pathname;
           <li>
             <a
               href={link.href}
-              class={`relative px-3 py-2 transition hover:text-teal-500 dark:hover:text-teal-400 ${
-                isActive && "text-teal-500 dark:text-teal-400"
-              }`}
+              class="relative py-2"
+              style={isActive
+                ? "color: var(--page-heading);"
+                : undefined}
             >
               {link.title}
               {isActive && (
                 <span
                   transition:name={TRANSITION_NAMES.activeNavHighlight}
-                  class="absolute inset-x-1 -bottom-[5px] h-px bg-gradient-to-r from-teal-500/0 via-teal-500/40 to-teal-500/0 dark:from-teal-400/0 dark:via-teal-400/40 dark:to-teal-400/0"
+                  class="absolute inset-x-0 -bottom-px h-px"
+                  style="background-color: var(--page-heading);"
                 />
               )}
             </a>
@@ -38,7 +41,8 @@ const currentPath = Astro.url.pathname;
 
 <button
   transition:name={TRANSITION_NAMES.responsiveNavButton}
-  class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20 md:hidden"
+  class="font-editorial-sans group flex items-center border px-3 py-2 text-[0.72rem] font-medium uppercase tracking-[0.16em] md:hidden"
+  style="border-color: var(--page-border); color: var(--page-heading); background-color: color-mix(in srgb, var(--page-panel) 75%, transparent);"
   id="primary-nav-button"
   >Menu<svg
     xmlns="http://www.w3.org/2000/svg"
@@ -46,7 +50,8 @@ const currentPath = Astro.url.pathname;
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
-    class="ml-3 h-auto w-2 stroke-zinc-500 group-hover:stroke-zinc-700 dark:group-hover:stroke-zinc-400"
+    class="ml-3 h-auto w-2"
+    style="stroke: var(--page-faint);"
   >
     <path
       stroke-linecap="round"
@@ -61,10 +66,11 @@ const currentPath = Astro.url.pathname;
 >
   <div
     id="primary-nav-content"
-    class="fixed inset-x-4 top-8 rounded-3xl bg-white p-8 ring-1 ring-zinc-900/5 dark:bg-zinc-900 dark:ring-zinc-800"
+    class="fixed inset-x-4 top-6 border p-6"
+    style="background-color: var(--page-panel); border-color: var(--page-border);"
   >
     <div class="flex flex-row items-center justify-between">
-      <h2 class="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+      <h2 class="font-editorial-mono text-[0.68rem] font-medium uppercase tracking-[0.18em]" style="color: var(--page-faint);">
         Navigation
       </h2>
       <form method="dialog">
@@ -75,7 +81,8 @@ const currentPath = Astro.url.pathname;
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="h-6 w-6 text-zinc-500 dark:text-zinc-400"
+            class="h-6 w-6"
+            style="color: var(--page-faint);"
           >
             <path
               stroke-linecap="round"
@@ -87,7 +94,8 @@ const currentPath = Astro.url.pathname;
     </div>
     <nav class="mt-4">
       <ul
-        class="divide-y divide-zinc-100 text-base text-zinc-800 dark:divide-zinc-100/5 dark:text-zinc-300"
+        class="divide-y text-base"
+        style="divide-color: var(--page-border); color: var(--page-text);"
       >
         {
           navLinks.map((link) => {
@@ -97,9 +105,8 @@ const currentPath = Astro.url.pathname;
               <li>
                 <a
                   href={link.href}
-                  class={`block py-2 hover:text-teal-500 dark:hover:text-teal-400 ${
-                    isActive && "text-teal-500 dark:text-teal-400"
-                  }`}
+                  class="block py-3"
+                  style={isActive ? "color: var(--page-link);" : undefined}
                 >
                   {link.title}
                 </a>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import MainLayout from "../layouts/MainLayout.astro";
 import Article from "../components/Article.astro";
 import Hero from "./components/Hero.astro";
+import HeroImages from "./components/HeroImages.astro";
 import Newsletter from "../components/Newsletter.astro";
 import { TRANSITION_NAMES } from "../constants/transition-names";
 const posts = (await getCollection("blog")).sort((a, b) => {
@@ -31,6 +32,11 @@ const social = (await getCollection("social"))[0]!;
 <MainLayout isHomePage={true} title="">
   <div class="mx-auto max-w-3xl pb-8 pt-10 sm:pt-14">
     <Hero />
+
+    <div class="mt-16">
+      <HeroImages />
+    </div>
+
     <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
         <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -2,35 +2,209 @@
 import { getCollection } from "astro:content";
 import MainLayout from "../layouts/MainLayout.astro";
 import Article from "../components/Article.astro";
-import Experience from "./components/Experience.astro";
 import Hero from "./components/Hero.astro";
 import Newsletter from "../components/Newsletter.astro";
+import { TRANSITION_NAMES } from "../constants/transition-names";
 const posts = (await getCollection("blog")).sort((a, b) => {
   const dateA = new Date(a.data.date).getTime();
   const dateB = new Date(b.data.date).getTime();
   return dateB - dateA;
 });
+const featuredPosts = posts.slice(0, 5);
+const newsletters = (await getCollection("rss"))
+  .sort((a, b) => b.data.dateMillis - a.data.dateMillis)
+  .slice(0, 3);
+const projects = (await getCollection("project"))[0]!.data.items.slice(0, 4);
+const experience = (await getCollection("career"))[0]!.data.items.slice(0, 3);
+const talks = (await getCollection("speaking"))
+  .sort((a, b) => b.data.year - a.data.year)
+  .flatMap((entry) =>
+    entry.data.events.map((event) => ({
+      year: entry.data.year,
+      ...event,
+    })),
+  )
+  .slice(0, 4);
+const social = (await getCollection("social"))[0]!;
 ---
 
 <MainLayout isHomePage={true} title="">
-  <div class="mt-9">
+  <div class="mx-auto max-w-3xl pb-8 pt-10 sm:pt-14">
     <Hero />
-  </div>
-  <!-- Placeholder for images section -->
-  <div class="hidden h-[320px] mobile:block md:h-[400px] lg:h-[448px]"></div>
-  <div
-    class="mt-12 flex flex-col-reverse gap-12 mobile:mt-0 lg:flex-row lg:items-stretch lg:justify-between"
-  >
-    <div class="flex max-w-xl flex-col gap-12">
-      {
-        posts.map((each) => {
-          return <Article {...each.data} slug={each.id} />;
-        })
-      }
-    </div>
-    <div class="flex flex-col gap-y-10">
-      <Newsletter />
-      <Experience />
-    </div>
+    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+        <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
+          Selected Writing
+        </h2>
+        <a href="/blog/" class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+          Browse all posts
+        </a>
+      </div>
+      <div class="mt-8 space-y-10">
+        {
+          featuredPosts.map((each) => {
+            return <Article {...each.data} slug={each.id} />;
+          })
+        }
+      </div>
+    </section>
+
+    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
+      <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div>
+          <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
+            Currently Shipping
+          </h2>
+          <p class="mt-4 max-w-2xl text-[1rem] leading-7" style="color: var(--page-muted);">
+            Recent work, things I’ve built, and the projects that still show up
+            in conversations long after shipping.
+          </p>
+
+          <div class="mt-8 space-y-6">
+            {
+              experience.map((item) => (
+                <article class="border-b pb-6" style="border-color: var(--page-border);">
+                  <div class="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+                    <h3 class="text-lg font-semibold" style="color: var(--page-heading);">
+                      {item.role}
+                    </h3>
+                    <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+                      {item.startDate} → {item.endDate}
+                    </p>
+                  </div>
+                  <p class="mt-1 text-sm" style="color: var(--page-link);">{item.company}</p>
+                  <p class="mt-3 text-[0.98rem] leading-7" style="color: var(--page-muted);">
+                    {item.description}
+                  </p>
+                </article>
+              ))
+            }
+          </div>
+        </div>
+
+        <aside class="space-y-4">
+          <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+            Selected Projects
+          </p>
+          <ul class="space-y-3">
+            {
+              projects.map((project) => (
+                <li class="border p-4" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);">
+                  <a href={project.link.href} target="_blank" rel="noopener">
+                    <span class="text-base font-semibold" style="color: var(--page-heading);">
+                      {project.name}
+                    </span>
+                    <span class="mt-2 block text-sm leading-7" style="color: var(--page-muted);">
+                      {project.description}
+                    </span>
+                    <span class="font-editorial-sans mt-3 block text-[0.72rem] font-medium uppercase tracking-[0.16em]" style="color: var(--page-link);">
+                      {project.link.label}
+                    </span>
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+          <a href="/projects/" class="font-editorial-mono inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+            See the full projects list
+          </a>
+        </aside>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
+      <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div>
+          <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
+            Speaking & Notes
+          </h2>
+          <div class="mt-8 space-y-6">
+            {
+              talks.map((talk) => (
+                <article class="border-b pb-6" style="border-color: var(--page-border);">
+                  <div class="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+                    <h3 class="text-lg font-semibold" style="color: var(--page-heading);">
+                      {talk.title}
+                    </h3>
+                    <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+                      {talk.year}
+                    </p>
+                  </div>
+                  <p class="mt-1 text-sm" style="color: var(--page-link);">{talk.name}</p>
+                  <p class="mt-3 text-[0.98rem] leading-7" style="color: var(--page-muted);">
+                    {talk.description}
+                  </p>
+                </article>
+              ))
+            }
+          </div>
+          <a href="/speaking/" class="font-editorial-mono mt-6 inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+            Browse all talks
+          </a>
+        </div>
+
+        <aside class="space-y-4">
+          <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+            Recent newsletters
+          </p>
+          <div class="space-y-4">
+            {
+              newsletters.map((entry) => (
+                <article class="border p-4" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);">
+                  <time
+                    class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]"
+                    style="color: var(--page-faint);"
+                    datetime={entry.data.dateValue}
+                    transition:name={`${TRANSITION_NAMES.newsletterTime}-${entry.id}`}
+                  >
+                    {entry.data.dateDisplay}
+                  </time>
+                  <h3
+                    class="mt-2 text-base font-semibold leading-7"
+                    style="color: var(--page-heading);"
+                    transition:name={`${TRANSITION_NAMES.newsletterTitle}-${entry.id}`}
+                  >
+                    <a href={`/newsletter/${entry.id}/`}>{entry.data.title}</a>
+                  </h3>
+                </article>
+              ))
+            }
+          </div>
+          <a href="/newsletter/" class="font-editorial-mono inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+            Read the archive
+          </a>
+        </aside>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
+      <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div>
+          <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
+            Newsletter
+          </h2>
+          <p class="mt-4 max-w-2xl text-[1rem] leading-7" style="color: var(--page-muted);">
+            I send occasional notes when something is worth sharing:
+            experiments, shipped work, talk recordings, and the odd technical
+            rabbit hole.
+          </p>
+          <div class="mt-6 max-w-xl">
+            <Newsletter />
+          </div>
+        </div>
+
+        <aside>
+          <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
+            Elsewhere
+          </p>
+          <ul class="mt-4 space-y-3 text-sm">
+            <li><a href={social.data.github} target="_blank" rel="noopener" style="color: var(--page-link);">GitHub</a></li>
+            <li><a href={social.data.linkedIn} target="_blank" rel="noopener" style="color: var(--page-link);">LinkedIn</a></li>
+            <li><a href={social.data.bluesky} target="_blank" rel="noopener" style="color: var(--page-link);">Bluesky</a></li>
+            <li><a href={`mailto:${social.data.email}`} style="color: var(--page-link);">{social.data.email}</a></li>
+          </ul>
+        </aside>
+      </div>
+    </section>
   </div>
 </MainLayout>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -42,7 +42,7 @@ const social = (await getCollection("social"))[0]!;
         <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
           Selected Writing
         </h2>
-        <a href="/blog/" class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+        <a href="/blog/" class="page-section-link">
           Browse all posts
         </a>
       </div>
@@ -95,7 +95,9 @@ const social = (await getCollection("social"))[0]!;
           <ul class="space-y-3">
             {
               projects.map((project) => (
-                <li class="border p-4" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);">
+                <li
+                  class="page-action-card"
+                >
                   <a href={project.link.href} target="_blank" rel="noopener">
                     <span class="text-base font-semibold" style="color: var(--page-heading);">
                       {project.name}
@@ -111,7 +113,7 @@ const social = (await getCollection("social"))[0]!;
               ))
             }
           </ul>
-          <a href="/projects/" class="font-editorial-mono inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+          <a href="/projects/" class="page-section-link">
             See the full projects list
           </a>
         </aside>
@@ -144,7 +146,7 @@ const social = (await getCollection("social"))[0]!;
               ))
             }
           </div>
-          <a href="/speaking/" class="font-editorial-mono mt-6 inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+          <a href="/speaking/" class="page-section-link mt-6">
             Browse all talks
           </a>
         </div>
@@ -156,7 +158,9 @@ const social = (await getCollection("social"))[0]!;
           <div class="space-y-4">
             {
               newsletters.map((entry) => (
-                <article class="border p-4" style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);">
+                <article
+                  class="page-action-card"
+                >
                   <time
                     class="font-editorial-mono text-[0.68rem] uppercase tracking-[0.18em]"
                     style="color: var(--page-faint);"
@@ -176,7 +180,7 @@ const social = (await getCollection("social"))[0]!;
               ))
             }
           </div>
-          <a href="/newsletter/" class="font-editorial-mono inline-block text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-link);">
+          <a href="/newsletter/" class="page-section-link">
             Read the archive
           </a>
         </aside>
@@ -204,10 +208,10 @@ const social = (await getCollection("social"))[0]!;
             Elsewhere
           </p>
           <ul class="mt-4 space-y-3 text-sm">
-            <li><a href={social.data.github} target="_blank" rel="noopener" style="color: var(--page-link);">GitHub</a></li>
-            <li><a href={social.data.linkedIn} target="_blank" rel="noopener" style="color: var(--page-link);">LinkedIn</a></li>
-            <li><a href={social.data.bluesky} target="_blank" rel="noopener" style="color: var(--page-link);">Bluesky</a></li>
-            <li><a href={`mailto:${social.data.email}`} style="color: var(--page-link);">{social.data.email}</a></li>
+            <li><a href={social.data.github} target="_blank" rel="noopener" class="page-inline-link">GitHub</a></li>
+            <li><a href={social.data.linkedIn} target="_blank" rel="noopener" class="page-inline-link">LinkedIn</a></li>
+            <li><a href={social.data.bluesky} target="_blank" rel="noopener" class="page-inline-link">Bluesky</a></li>
+            <li><a href={`mailto:${social.data.email}`} class="page-inline-link">{social.data.email}</a></li>
           </ul>
         </aside>
       </div>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -30,14 +30,14 @@ const social = (await getCollection("social"))[0]!;
 ---
 
 <MainLayout isHomePage={true} title="">
-  <div class="mx-auto max-w-3xl pb-8 pt-10 sm:pt-14">
+  <div class="mx-auto max-w-4xl pb-16 pt-14 sm:pt-18">
     <Hero />
 
-    <div class="mt-16">
+    <div class="mt-20 sm:mt-24">
       <HeroImages />
     </div>
 
-    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
+    <section class="mt-20 pt-8 sm:mt-24 sm:pt-10">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
         <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
           Selected Writing
@@ -46,7 +46,7 @@ const social = (await getCollection("social"))[0]!;
           Browse all posts
         </a>
       </div>
-      <div class="mt-8 space-y-10">
+      <div class="mt-10 space-y-12 sm:mt-12 sm:space-y-14">
         {
           featuredPosts.map((each) => {
             return <Article {...each.data} slug={each.id} />;
@@ -55,21 +55,21 @@ const social = (await getCollection("social"))[0]!;
       </div>
     </section>
 
-    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
-      <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_18rem]">
+    <section class="mt-24 sm:mt-28">
+      <div class="grid gap-16 lg:grid-cols-[minmax(0,1.15fr)_20rem] lg:gap-20">
         <div>
           <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
             Currently Shipping
           </h2>
-          <p class="mt-4 max-w-2xl text-[1rem] leading-7" style="color: var(--page-muted);">
+          <p class="mt-5 max-w-2xl text-[1rem] leading-8" style="color: var(--page-muted);">
             Recent work, things I’ve built, and the projects that still show up
             in conversations long after shipping.
           </p>
 
-          <div class="mt-8 space-y-6">
+          <div class="mt-10 space-y-8">
             {
               experience.map((item) => (
-                <article class="border-b pb-6" style="border-color: var(--page-border);">
+                <article class="border-b pb-8" style="border-color: var(--page-border);">
                   <div class="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
                     <h3 class="text-lg font-semibold" style="color: var(--page-heading);">
                       {item.role}
@@ -79,7 +79,7 @@ const social = (await getCollection("social"))[0]!;
                     </p>
                   </div>
                   <p class="mt-1 text-sm" style="color: var(--page-link);">{item.company}</p>
-                  <p class="mt-3 text-[0.98rem] leading-7" style="color: var(--page-muted);">
+                  <p class="mt-4 text-[0.98rem] leading-8" style="color: var(--page-muted);">
                     {item.description}
                   </p>
                 </article>
@@ -88,11 +88,11 @@ const social = (await getCollection("social"))[0]!;
           </div>
         </div>
 
-        <aside class="space-y-4">
+        <aside class="space-y-6">
           <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
             Selected Projects
           </p>
-          <ul class="space-y-3">
+          <ul class="space-y-4">
             {
               projects.map((project) => (
                 <li
@@ -120,16 +120,16 @@ const social = (await getCollection("social"))[0]!;
       </div>
     </section>
 
-    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
-      <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_18rem]">
+    <section class="mt-24 sm:mt-28">
+      <div class="grid gap-16 lg:grid-cols-[minmax(0,1.15fr)_20rem] lg:gap-20">
         <div>
           <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
             Speaking & Notes
           </h2>
-          <div class="mt-8 space-y-6">
+          <div class="mt-10 space-y-8">
             {
               talks.map((talk) => (
-                <article class="border-b pb-6" style="border-color: var(--page-border);">
+                <article class="border-b pb-8" style="border-color: var(--page-border);">
                   <div class="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
                     <h3 class="text-lg font-semibold" style="color: var(--page-heading);">
                       {talk.title}
@@ -139,23 +139,23 @@ const social = (await getCollection("social"))[0]!;
                     </p>
                   </div>
                   <p class="mt-1 text-sm" style="color: var(--page-link);">{talk.name}</p>
-                  <p class="mt-3 text-[0.98rem] leading-7" style="color: var(--page-muted);">
+                  <p class="mt-4 text-[0.98rem] leading-8" style="color: var(--page-muted);">
                     {talk.description}
                   </p>
                 </article>
               ))
             }
           </div>
-          <a href="/speaking/" class="page-section-link mt-6">
+          <a href="/speaking/" class="page-section-link mt-8">
             Browse all talks
           </a>
         </div>
 
-        <aside class="space-y-4">
+        <aside class="space-y-6">
           <p class="font-editorial-mono text-[0.72rem] uppercase tracking-[0.18em]" style="color: var(--page-faint);">
             Recent newsletters
           </p>
-          <div class="space-y-4">
+          <div class="space-y-5">
             {
               newsletters.map((entry) => (
                 <article
@@ -170,7 +170,7 @@ const social = (await getCollection("social"))[0]!;
                     {entry.data.dateDisplay}
                   </time>
                   <h3
-                    class="mt-2 text-base font-semibold leading-7"
+                    class="mt-3 text-base font-semibold leading-8"
                     style="color: var(--page-heading);"
                     transition:name={`${TRANSITION_NAMES.newsletterTitle}-${entry.id}`}
                   >
@@ -187,18 +187,18 @@ const social = (await getCollection("social"))[0]!;
       </div>
     </section>
 
-    <section class="mt-16 border-t pt-8" style="border-color: var(--page-border);">
-      <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem]">
+    <section class="mt-24 border-t pt-12 sm:mt-28 sm:pt-14" style="border-color: var(--page-border);">
+      <div class="grid gap-14 lg:grid-cols-[minmax(0,1.15fr)_20rem] lg:gap-18">
         <div>
           <h2 class="font-editorial-sans text-sm font-semibold uppercase tracking-[0.16em]" style="color: var(--page-heading);">
             Newsletter
           </h2>
-          <p class="mt-4 max-w-2xl text-[1rem] leading-7" style="color: var(--page-muted);">
+          <p class="mt-5 max-w-2xl text-[1rem] leading-8" style="color: var(--page-muted);">
             I send occasional notes when something is worth sharing:
             experiments, shipped work, talk recordings, and the odd technical
             rabbit hole.
           </p>
-          <div class="mt-6 max-w-xl">
+          <div class="mt-8 max-w-xl">
             <Newsletter />
           </div>
         </div>

--- a/daniakash.com/src/pages/newsletter.astro
+++ b/daniakash.com/src/pages/newsletter.astro
@@ -29,14 +29,12 @@ const rss = (await getCollection("rss")).sort(
         (I promise).</a
       >
     </Header>
-    <div class="mt-16 max-w-2xl sm:mt-20">
+    <div class="mt-20 max-w-3xl sm:mt-24">
       <NewsletterForm />
     </div>
-    <div class="mt-16 sm:mt-20">
-      <div
-        class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40"
-      >
-        <div class="flex max-w-3xl flex-col space-y-16">
+    <div class="mt-20 sm:mt-24">
+      <div>
+        <div class="flex max-w-4xl flex-col space-y-20">
           {
             rss.map((each) => {
               return (

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import type { GetStaticPaths } from "astro";
+import { fade } from "astro:transitions";
 import MainLayout from "../../layouts/MainLayout.astro";
 import ArticleContainer from "../../components/ArticleContainer.astro";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
@@ -49,6 +50,7 @@ await getOGImage({
       <h1
         class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl"
         transition:name={`${TRANSITION_NAMES.newsletterTitle}-${slug}`}
+        transition:animate={fade({ duration: 220 })}
       >
         {title}
       </h1>
@@ -56,6 +58,7 @@ await getOGImage({
         datetime={dateValue}
         class="order-first flex items-center text-base text-zinc-400 dark:text-zinc-500"
         transition:name={`${TRANSITION_NAMES.newsletterTime}-${slug}`}
+        transition:animate={fade({ duration: 180 })}
       >
         <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"
         ></span>

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import { fade } from "astro:transitions";
 import MainLayout from "../../layouts/MainLayout.astro";
 import { getCollection, render } from "astro:content";
 import { TRANSITION_NAMES } from "../../constants/transition-names";
@@ -44,6 +45,7 @@ await getOGImage({
         <h1
           class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl"
           transition:name={`${TRANSITION_NAMES.blogTitle}-${post.id}`}
+          transition:animate={fade({ duration: 220 })}
         >
           {post.data.title}
         </h1>
@@ -51,6 +53,7 @@ await getOGImage({
           datetime={dateValue}
           class="order-first flex items-center text-base text-zinc-400 dark:text-zinc-500"
           transition:name={`${TRANSITION_NAMES.blogTime}-${post.id}`}
+          transition:animate={fade({ duration: 180 })}
         >
           <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"
           ></span>

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -16,10 +16,10 @@ const projects = (await getCollection("project"))[0]!;
       title="Things I’ve Built"
       subtitle="From tiny experiments to giant time-sinks, here’s what’s kept me busy."
     />
-    <div class="mt-16 sm:mt-20">
+    <div class="mt-20 sm:mt-24">
       <ul
         role="list"
-        class="grid grid-cols-1 gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3"
+        class="grid grid-cols-1 gap-x-16 gap-y-24 sm:grid-cols-2 lg:grid-cols-3"
       >
         {
           projects.data.items.map((project) => {
@@ -45,23 +45,23 @@ const projects = (await getCollection("project"))[0]!;
                     loading="eager"
                   />
                 </div>
-                <h2 class="mt-6 text-base font-semibold text-zinc-800 dark:text-zinc-100">
+                <h2 class="mt-7 text-base font-semibold text-zinc-800 dark:text-zinc-100">
                   <div
                     class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
                     style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
                   />
                   <a href={project.link.href} target="_blank" rel="noopener">
-                    <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6" />
+                    <span class="absolute -inset-x-4 -inset-y-7 z-20 sm:-inset-x-6" />
                     <span class="relative z-10">{project.name}</span>
                   </a>
                 </h2>
-                <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                <p class="relative z-10 mt-3 text-sm leading-7 text-zinc-600 dark:text-zinc-400">
                   {project.description}{" "}
                   {project.info ? (
                     <span class="text-[0.7rem] italic">{project.info}</span>
                   ) : null}
                 </p>
-                <p class="relative z-10 mt-6 flex text-sm font-medium text-zinc-400 transition group-hover:text-teal-500 dark:text-zinc-200">
+                <p class="relative z-10 mt-7 flex text-sm font-medium text-zinc-400 transition group-hover:text-teal-500 dark:text-zinc-200">
                   <LinkIcon />
                   <span class="ml-2">{project.link.label}</span>
                 </p>

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -46,9 +46,12 @@ const projects = (await getCollection("project"))[0]!;
                   />
                 </div>
                 <h2 class="mt-6 text-base font-semibold text-zinc-800 dark:text-zinc-100">
-                  <div class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl" />
+                  <div
+                    class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+                    style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
+                  />
                   <a href={project.link.href} target="_blank" rel="noopener">
-                    <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
+                    <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6" />
                     <span class="relative z-10">{project.name}</span>
                   </a>
                 </h2>

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -17,17 +17,17 @@ const events = (await getCollection("speaking")).sort(
       title="Words I’ve Said"
       subtitle="You can actually hear me talk, not just type."
     />
-    <div class="mt-20 sm:mt-24">
-      <div class="space-y-28">
+    <div class="mt-16 sm:mt-20">
+      <div class="space-y-20">
         {
           events.map((each) => {
             const sectionId = `speaking-year-${each.data.year}`;
             return (
               <section
                 aria-labelledby={sectionId}
-                class=""
+                class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40"
               >
-                <div class="grid max-w-4xl grid-cols-1 items-baseline gap-y-10 md:grid-cols-[7rem_minmax(0,1fr)] md:gap-x-10">
+                <div class="grid max-w-3xl grid-cols-1 items-baseline gap-y-8 md:grid-cols-4">
                   <h2
                     id={sectionId}
                     class="text-sm font-semibold text-zinc-800 dark:text-zinc-100"
@@ -35,7 +35,7 @@ const events = (await getCollection("speaking")).sort(
                     {each.data.year}
                   </h2>
                   <div class="md:col-span-3">
-                    <div class="space-y-20">
+                    <div class="space-y-16">
                       {each.data.events.map((event) => {
                         const youtubeThumbnail = getYoutubeThumbnail(
                           event.video ?? "",
@@ -59,9 +59,9 @@ const events = (await getCollection("speaking")).sort(
                                 loading="lazy"
                               />
                             ) : null}
-                            <h3 class="mt-5 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
+                            <h3 class="mt-4 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
                               <div
-                                class="absolute -inset-x-4 -inset-y-7 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+                                class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
                                 style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
                               />
                               {primaryLink ? (
@@ -70,7 +70,7 @@ const events = (await getCollection("speaking")).sort(
                                   target="_blank"
                                   rel="noopener"
                                 >
-                                  <span class="absolute -inset-x-4 -inset-y-7 z-20 sm:-inset-x-6" />
+                                  <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6" />
                                   <span class="relative z-10">
                                     {event.title}
                                   </span>
@@ -88,11 +88,11 @@ const events = (await getCollection("speaking")).sort(
                               </span>
                               {event.name}
                             </p>
-                            <p class="relative z-10 mt-3 text-sm leading-7 text-zinc-600 dark:text-zinc-400">
+                            <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">
                               {event.description}
                             </p>
                           </article>
-                          <div class="mt-7 flex flex-wrap gap-x-5 gap-y-3">
+                          <div style="margin-top:30px" class="flex gap-5">
                             {event.cta?.map((cta) => {
                               return (
                                 <a

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -17,17 +17,17 @@ const events = (await getCollection("speaking")).sort(
       title="Words I’ve Said"
       subtitle="You can actually hear me talk, not just type."
     />
-    <div class="mt-16 sm:mt-20">
-      <div class="space-y-20">
+    <div class="mt-20 sm:mt-24">
+      <div class="space-y-28">
         {
           events.map((each) => {
             const sectionId = `speaking-year-${each.data.year}`;
             return (
               <section
                 aria-labelledby={sectionId}
-                class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40"
+                class=""
               >
-                <div class="grid max-w-3xl grid-cols-1 items-baseline gap-y-8 md:grid-cols-4">
+                <div class="grid max-w-4xl grid-cols-1 items-baseline gap-y-10 md:grid-cols-[7rem_minmax(0,1fr)] md:gap-x-10">
                   <h2
                     id={sectionId}
                     class="text-sm font-semibold text-zinc-800 dark:text-zinc-100"
@@ -35,7 +35,7 @@ const events = (await getCollection("speaking")).sort(
                     {each.data.year}
                   </h2>
                   <div class="md:col-span-3">
-                    <div class="space-y-16">
+                    <div class="space-y-20">
                       {each.data.events.map((event) => {
                         const youtubeThumbnail = getYoutubeThumbnail(
                           event.video ?? "",
@@ -59,9 +59,9 @@ const events = (await getCollection("speaking")).sort(
                                 loading="lazy"
                               />
                             ) : null}
-                            <h3 class="mt-4 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
+                            <h3 class="mt-5 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
                               <div
-                                class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+                                class="absolute -inset-x-4 -inset-y-7 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
                                 style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
                               />
                               {primaryLink ? (
@@ -70,7 +70,7 @@ const events = (await getCollection("speaking")).sort(
                                   target="_blank"
                                   rel="noopener"
                                 >
-                                  <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6" />
+                                  <span class="absolute -inset-x-4 -inset-y-7 z-20 sm:-inset-x-6" />
                                   <span class="relative z-10">
                                     {event.title}
                                   </span>
@@ -88,11 +88,11 @@ const events = (await getCollection("speaking")).sort(
                               </span>
                               {event.name}
                             </p>
-                            <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                            <p class="relative z-10 mt-3 text-sm leading-7 text-zinc-600 dark:text-zinc-400">
                               {event.description}
                             </p>
                           </article>
-                          <div style="margin-top:30px" class="flex gap-5">
+                          <div class="mt-7 flex flex-wrap gap-x-5 gap-y-3">
                             {event.cta?.map((cta) => {
                               return (
                                 <a

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -60,14 +60,17 @@ const events = (await getCollection("speaking")).sort(
                               />
                             ) : null}
                             <h3 class="mt-4 text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100">
-                              <div class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl" />
+                              <div
+                                class="absolute -inset-x-4 -inset-y-6 z-0 border opacity-0 transition group-hover:opacity-100 sm:-inset-x-6"
+                                style="border-color: var(--page-border); background-color: color-mix(in srgb, var(--page-panel) 80%, transparent);"
+                              />
                               {primaryLink ? (
                                 <a
                                   href={primaryLink}
                                   target="_blank"
                                   rel="noopener"
                                 >
-                                  <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
+                                  <span class="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6" />
                                   <span class="relative z-10">
                                     {event.title}
                                   </span>

--- a/daniakash.com/src/styles/global.css
+++ b/daniakash.com/src/styles/global.css
@@ -1,4 +1,15 @@
 @import "tailwindcss";
+@import "@fontsource/monaspace-neon/400.css";
+@import "@fontsource/monaspace-neon/400-italic.css";
+@import "@fontsource/monaspace-neon/500.css";
+@import "@fontsource/monaspace-neon/500-italic.css";
+@import "@fontsource/monaspace-neon/600.css";
+@import "@fontsource/monaspace-radon/500.css";
+@import "@fontsource/monaspace-radon/600.css";
+@import "@fontsource/monaspace-radon/700.css";
+@import "@fontsource/monaspace-xenon/500.css";
+@import "@fontsource/monaspace-xenon/600.css";
+@import "@fontsource/monaspace-xenon/700.css";
 @config "../../tailwind.config.mjs";
 @plugin "@tailwindcss/typography";
 
@@ -40,15 +51,50 @@ html {
 
 body {
   color: var(--page-text);
-  font-family:
-    "Iowan Old Style",
-    "Palatino Linotype",
-    "Book Antiqua",
-    "New York",
-    "Times New Roman",
-    serif;
+  font-family: "Monaspace Neon", monospace;
+  font-feature-settings:
+    "calt" 1,
+    "liga" 1,
+    "ss01" 1,
+    "ss02" 1,
+    "ss03" 1,
+    "ss04" 1,
+    "ss05" 1,
+    "ss06" 1;
+  font-variant-ligatures: common-ligatures contextual discretionary-ligatures;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+}
+
+h1 {
+  font-family: "Monaspace Radon", monospace;
+  font-feature-settings:
+    "calt" 1,
+    "liga" 1,
+    "ss01" 1,
+    "ss02" 1,
+    "ss03" 1,
+    "ss07" 1,
+    "ss08" 1,
+    "ss09" 1,
+    "ss10" 1;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Monaspace Xenon", monospace;
+  font-feature-settings:
+    "calt" 1,
+    "liga" 1,
+    "ss01" 1,
+    "ss02" 1,
+    "ss03" 1,
+    "ss04" 1,
+    "ss05" 1,
+    "ss06" 1;
 }
 
 ::selection {
@@ -132,20 +178,29 @@ a {
 }
 
 .font-editorial-sans {
-  font-family:
-    "Avenir Next",
-    "Segoe UI",
-    "Helvetica Neue",
-    sans-serif;
+  font-family: "Monaspace Neon", monospace;
+  font-feature-settings:
+    "calt" 1,
+    "liga" 1,
+    "ss01" 1,
+    "ss02" 1,
+    "ss03" 1,
+    "ss04" 1,
+    "ss05" 1,
+    "ss06" 1;
 }
 
 .font-editorial-mono {
-  font-family:
-    "SFMono-Regular",
-    "JetBrains Mono",
-    "IBM Plex Mono",
-    "Menlo",
-    monospace;
+  font-family: "Monaspace Neon", monospace;
+  font-feature-settings:
+    "calt" 1,
+    "liga" 1,
+    "ss01" 1,
+    "ss02" 1,
+    "ss03" 1,
+    "ss04" 1,
+    "ss05" 1,
+    "ss06" 1;
 }
 
 ::view-transition-old(hero-title),

--- a/daniakash.com/src/styles/global.css
+++ b/daniakash.com/src/styles/global.css
@@ -63,6 +63,74 @@ a {
     background-color 180ms ease;
 }
 
+@layer components {
+  .page-inline-link {
+    @apply underline decoration-1 underline-offset-4;
+    color: var(--page-link);
+    text-decoration-color: color-mix(in srgb, var(--page-link) 45%, transparent);
+  }
+
+  .page-inline-link:hover {
+    color: var(--page-link-hover);
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--page-link-hover) 70%,
+      transparent
+    );
+  }
+
+  .page-section-link {
+    @apply inline-block border-b text-[0.72rem] uppercase tracking-[0.18em];
+    font-family:
+      "SFMono-Regular",
+      "JetBrains Mono",
+      "IBM Plex Mono",
+      "Menlo",
+      monospace;
+    color: var(--page-link);
+    border-color: color-mix(in srgb, var(--page-link) 70%, transparent);
+  }
+
+  .page-section-link:hover {
+    color: var(--page-link-hover);
+    border-color: var(--page-link-hover);
+  }
+
+  .page-action-chip {
+    @apply inline-flex items-center gap-2 border px-3 py-2 transition duration-200 hover:-translate-y-0.5;
+    color: var(--page-link);
+    border-color: var(--page-border);
+    background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);
+  }
+
+  .page-action-chip:hover {
+    color: var(--page-link-hover);
+    border-color: var(--page-strong-border);
+    background-color: color-mix(in srgb, var(--page-panel) 92%, transparent);
+  }
+
+  .page-action-card {
+    @apply block border p-4 transition duration-200 hover:-translate-y-0.5;
+    border-color: var(--page-border);
+    background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);
+  }
+
+  .page-action-card:hover {
+    border-color: var(--page-strong-border);
+    background-color: color-mix(in srgb, var(--page-panel) 90%, transparent);
+  }
+
+  .page-hover-frame {
+    @apply border opacity-0 transition duration-200;
+    border-color: var(--page-strong-border);
+    background-color: color-mix(in srgb, var(--page-panel) 82%, transparent);
+  }
+
+  .group:hover .page-hover-frame {
+    @apply opacity-100;
+  }
+}
+
 .font-editorial-sans {
   font-family:
     "Avenir Next",

--- a/daniakash.com/src/styles/global.css
+++ b/daniakash.com/src/styles/global.css
@@ -42,6 +42,7 @@ html.dark {
 }
 
 html {
+  font-size: 15px;
   background:
     radial-gradient(circle at top, var(--page-bg-accent), transparent 38%),
     var(--page-bg);

--- a/daniakash.com/src/styles/global.css
+++ b/daniakash.com/src/styles/global.css
@@ -1,3 +1,103 @@
 @import "tailwindcss";
 @config "../../tailwind.config.mjs";
 @plugin "@tailwindcss/typography";
+
+:root {
+  --page-bg: #f6f1e8;
+  --page-bg-accent: rgba(224, 213, 195, 0.35);
+  --page-panel: rgba(255, 251, 245, 0.86);
+  --page-border: rgba(68, 58, 43, 0.14);
+  --page-strong-border: rgba(68, 58, 43, 0.22);
+  --page-text: #201b16;
+  --page-muted: #6e665d;
+  --page-faint: #938a80;
+  --page-link: #0f766e;
+  --page-link-hover: #115e59;
+  --page-heading: #17120e;
+}
+
+html.dark {
+  --page-bg: #12100d;
+  --page-bg-accent: rgba(96, 80, 63, 0.18);
+  --page-panel: rgba(25, 22, 19, 0.84);
+  --page-border: rgba(223, 213, 199, 0.1);
+  --page-strong-border: rgba(223, 213, 199, 0.18);
+  --page-text: #e6ddd2;
+  --page-muted: #b3a89b;
+  --page-faint: #8f857b;
+  --page-link: #5eead4;
+  --page-link-hover: #99f6e4;
+  --page-heading: #fbf6ef;
+}
+
+html {
+  background:
+    radial-gradient(circle at top, var(--page-bg-accent), transparent 38%),
+    var(--page-bg);
+  color: var(--page-text);
+  scroll-behavior: smooth;
+}
+
+body {
+  color: var(--page-text);
+  font-family:
+    "Iowan Old Style",
+    "Palatino Linotype",
+    "Book Antiqua",
+    "New York",
+    "Times New Roman",
+    serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--page-link) 22%, transparent);
+}
+
+a {
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    opacity 180ms ease,
+    background-color 180ms ease;
+}
+
+.font-editorial-sans {
+  font-family:
+    "Avenir Next",
+    "Segoe UI",
+    "Helvetica Neue",
+    sans-serif;
+}
+
+.font-editorial-mono {
+  font-family:
+    "SFMono-Regular",
+    "JetBrains Mono",
+    "IBM Plex Mono",
+    "Menlo",
+    monospace;
+}
+
+::view-transition-old(hero-title),
+::view-transition-new(hero-title) {
+  animation-duration: 320ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(avatar),
+::view-transition-new(avatar) {
+  animation-duration: 260ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+::view-transition-old(active-nav-highlight),
+::view-transition-new(active-nav-highlight),
+::view-transition-old(dark-mode-toggle),
+::view-transition-new(dark-mode-toggle),
+::view-transition-old(footer),
+::view-transition-new(footer) {
+  animation-duration: 220ms;
+  animation-timing-function: ease;
+}

--- a/daniakash.com/src/styles/global.css
+++ b/daniakash.com/src/styles/global.css
@@ -144,7 +144,7 @@ a {
   }
 
   .page-action-chip {
-    @apply inline-flex items-center gap-2 border px-3 py-2 transition duration-200 hover:-translate-y-0.5;
+    @apply inline-flex items-center gap-2 border px-3.5 py-2.5 transition duration-200 hover:-translate-y-0.5;
     color: var(--page-link);
     border-color: var(--page-border);
     background-color: color-mix(in srgb, var(--page-panel) 72%, transparent);
@@ -157,7 +157,7 @@ a {
   }
 
   .page-action-card {
-    @apply block border p-4 transition duration-200 hover:-translate-y-0.5;
+    @apply block border p-5 transition duration-200 hover:-translate-y-0.5 sm:p-6;
     border-color: var(--page-border);
     background-color: color-mix(in srgb, var(--page-panel) 68%, transparent);
   }

--- a/daniakash.com/src/utils/getOGImage.ts
+++ b/daniakash.com/src/utils/getOGImage.ts
@@ -32,7 +32,10 @@ export const getOGImage = async ({
         {
           type: "div",
           props: {
-            tw: "flex flex-col gap-4",
+            tw: "flex flex-col",
+            style: {
+              gap: "16px",
+            },
             children: [
               {
                 type: "h1",
@@ -59,7 +62,10 @@ export const getOGImage = async ({
               {
                 type: "div",
                 props: {
-                  tw: "flex items-center gap-4",
+                  tw: "flex items-center",
+                  style: {
+                    gap: "16px",
+                  },
                   children: [
                     {
                       type: "img",


### PR DESCRIPTION
## Summary
- redesign the homepage into a PlanetScale-inspired markdown-style document layout
- simplify the site shell, navigation, hero, newsletter block, and footer into a more editorial presentation
- preserve existing content sources while keeping and refining shared view transitions across key elements

## Verification
- pnpm build