### PR TITLE
feat: update projects page with new project data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@
 
 I design and develop intelligent systems — from browser-native AI agents that navigate the web autonomously, to tools that make AI practical for everyday workflows. My work sits at the intersection of browser engineering, AI agents, and developer tooling.
 
-Expert in vibe coding and prompt engineering — but I've been shipping complete products solo long before the age of AI.
+> Expert in vibe coding and prompt engineering — but I've been shipping complete products solo long before the age of AI.
 
 ## Current Projects
 
-- 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — AI-powered browser platform that gives agents a real browser to work with
-- 🧬 **[Inaily](https://inaily.com/)** — AI-native personal wellness
-- 🧠 **[Skills](https://github.com/DaniAkash/skills)** — Teaching AI agents how to use React's useEffect correctly
-- 🧱 **[Wikiwall](https://github.com/2dapps/wikiwall)** — Collaborative wiki walls
+- 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — The Open Source Agentic Browser
+- 🤝 **[Inaily](https://inaily.com/)** — Meet the right people at every conference
+- 🧠 **[Skills](https://github.com/DaniAkash/skills)** — Teaching AI agents how to code in my style
+- 🧱 **[Wikiwall](https://github.com/2dapps/wikiwall)** — Display wikipedia articles as wallpapers
 
 ## Previously Worked On
 
@@ -38,16 +38,7 @@ Expert in vibe coding and prompt engineering — but I've been shipping complete
 - 🌍 **[Pickyourtrail Travel Guide](https://pickyourtrail.com/guides/)** — Destination travel guides
 - 📦 **[React Native Toolkit](https://github.com/react-native-toolkit)** — Collection of React Native utilities and tools
 - 📖 **[React Native Docs](https://github.com/facebook/react-native-website/issues/1579)** — Contributed to React Native documentation
-- 📚 **[JavaScript By Example](https://www.oreilly.com/library/view/javascript-by-example/9781788293969/)** — Author, O'Reilly
-
-## Open Source Libraries
-
-- 📐 **[react-native-responsive-dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions)** — Responsive fontSize, height & width for React Native (473⭐)
-- ✏️ **[react-native-draftjs](https://github.com/DaniAkash/react-native-draftjs)** — Full-fledged React Native rich text editor based on Draft.js (133⭐)
-- 🔄 **[rex-state](https://github.com/DaniAkash/rex-state)** — Convert hooks into shared states between React components (30⭐)
-- 📱 **[react-native-masonry-scrollview](https://github.com/DaniAkash/react-native-masonry-scrollview)** — Pinterest-style masonry layout for React Native
-- 🔌 **[lifecycle-hooks](https://github.com/DaniAkash/lifecycle-hooks)** — React lifecycle as hooks
-- ⚡ **[vite-plugin-esm.sh](https://github.com/DaniAkash/vite-plugin-esm.sh)** — Rewrite imports with esm.sh at build time
+- 📚 **[JavaScript By Example](https://www.oreilly.com/library/view/javascript-by-example/9781788293969/)** — Book Author
 
 ## Latest Blog Posts
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,95 @@
-# Hey, I'm Dani Akash 👋
+# Hi, I'm Dani 👋
 
-Building [BrowserOS](https://github.com/browseros-ai/BrowserOS) — an open-source agentic browser
-that lets AI see, interact with, and automate the web.
+📍 **Chennai, India** | 🤖 **A Simple Developer Building AI Agents for Humans** | 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)**
 
-Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in Chennai, India.
+![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![JavaScript](https://img.shields.io/badge/-JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
+![React](https://img.shields.io/badge/-React-61DAFB?style=flat-square&logo=react&logoColor=black)
+![React Native](https://img.shields.io/badge/-React_Native-61DAFB?style=flat-square&logo=react&logoColor=black)
+![Node.js](https://img.shields.io/badge/-Node.js-339933?style=flat-square&logo=node.js&logoColor=white)
+![Python](https://img.shields.io/badge/-Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Claude](https://img.shields.io/badge/-Claude-000000?style=flat-square&logo=anthropic&logoColor=white)
+![Astro](https://img.shields.io/badge/-Astro-FF5D01?style=flat-square&logo=astro&logoColor=white)
+![Vite](https://img.shields.io/badge/-Vite-646CFF?style=flat-square&logo=vite&logoColor=white)
+![Web](https://img.shields.io/badge/-Web-4285F4?style=flat-square&logo=google-chrome&logoColor=white)
 
-## What I do
+> A simple developer building AI agents for humans. I believe the best tools are the ones that get out of your way — and the best agents are the ones that actually do things.
 
-I design and develop intelligent systems — from browser-native AI agents that navigate the web autonomously, to tools that make AI practical for everyday workflows. My work sits at the intersection of browser engineering, AI agents, and developer tooling.
+## Current Projects
 
-## Beyond code
+- 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — AI-powered browser platform that gives agents a real browser to work with
+- 🧬 **[Inaily](https://inaily.com/)** — AI-native personal wellness
+- 🧠 **[Skills](https://github.com/DaniAkash/skills)** — Teaching AI agents how to use React's useEffect correctly
+- 🧱 **[Wikiwall](https://github.com/2dapps/wikiwall)** — Collaborative wiki walls
 
-I'm a regular speaker at tech communities in Chennai and Bangalore — talking about AI agents, browser internals, and building products with small teams.
+## Open Source Libraries
 
-Open to discuss and brainstorm startup ideas — reach out on [X](https://twitter.com/dani_akash_).
+- 📐 **[react-native-responsive-dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions)** — Responsive fontSize, height & width for React Native (473⭐)
+- ✏️ **[react-native-draftjs](https://github.com/DaniAkash/react-native-draftjs)** — Full-fledged React Native rich text editor based on Draft.js (133⭐)
+- 🔄 **[rex-state](https://github.com/DaniAkash/rex-state)** — Convert hooks into shared states between React components (30⭐)
+- 📱 **[react-native-masonry-scrollview](https://github.com/DaniAkash/react-native-masonry-scrollview)** — Pinterest-style masonry layout for React Native
+- 🔌 **[lifecycle-hooks](https://github.com/DaniAkash/lifecycle-hooks)** — React lifecycle as hooks
+- ⚡ **[vite-plugin-esm.sh](https://github.com/DaniAkash/vite-plugin-esm.sh)** — Rewrite imports with esm.sh at build time
 
-Currently also building [Inaily](https://inaily.com) — an app for AI-driven networking at meetups.
+## Previously Worked On
 
-## How I work
+- 🧠 **[Clarifai Node.js](https://github.com/Clarifai/clarifai-nodejs)** — Official Node.js client for the Clarifai AI platform
+- 🔀 **[Cosmo](https://github.com/wundergraph/cosmo)** — Open-source GraphQL federation by WunderGraph
+- 👁️ **[Open Previews](https://github.com/wundergraph/open-previews)** — Open-source preview environments by WunderGraph
+- 🔗 **[OSlash](https://oslash.com)** — Browser extension for team knowledge shortcuts
+- ✈️ **[Pickyourtrail](https://play.google.com/store/apps/details?id=com.pickyourtrail&hl=en&gl=US)** — Travel planner app
+- 🌍 **[Pickyourtrail Travel Guide](https://pickyourtrail.com/guides/)** — Destination travel guides
+- 📦 **[React Native Toolkit](https://github.com/react-native-toolkit)** — Collection of React Native utilities and tools
+- 📖 **[React Native Docs](https://github.com/facebook/react-native-website/issues/1579)** — Contributed to React Native documentation
+- 📚 **[JavaScript By Example](https://www.oreilly.com/library/view/javascript-by-example/9781788293969/)** — Technical reviewer for O'Reilly book
 
-Expert in vibe coding and prompt engineering — but I've been shipping complete products solo long before the age of AI.
+## GitHub Activity
 
-I will automate any and all boring stuff (I live by this rule).
+![GitHub Contribution Graph](https://ghchart.rshah.org/DaniAkash)
+
+## Latest Blog Posts
+
+### From [daniakash.com](https://daniakash.com)
+- [Wrapping up 2024](https://daniakash.com/newsletter/wrapping-up-2024/)
+- [The Developer Edition](https://daniakash.com/newsletter/the-developer-edition/)
+- [Swimming Robots in Space](https://daniakash.com/newsletter/swimming-robots-in-space/)
+- [AI needs water — a lot!](https://daniakash.com/newsletter/ai-needs-water-a-lot/)
+- [$1 Trillion Dollar Goal](https://daniakash.com/newsletter/1-trillion-dollar-goal/)
+
+### From [browseros.com](https://www.browseros.com)
+- [Have a ChatGPT Subscription and a Windows PC? Now Give It a Browser.](https://www.browseros.com/blog/bring-your-own-agent)
+- [Your Browser Agent Now Has a Soul (And It Never Leaves Your Machine)](https://www.browseros.com/blog/soul-memory-engineering)
+- [Kimi K2.5 Now Available in BrowserOS](https://www.browseros.com/blog/kimi-browseros-partnership)
 
 ## Connect
 
-[Website](https://daniakash.com) · [Bluesky](https://bsky.app/profile/daniakash.com) · [X](https://twitter.com/dani_akash_) · [LinkedIn](https://linkedin.com/in/daniakash)
+[![X](https://img.shields.io/badge/-@dani__akash__-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/dani_akash_)
+[![Bluesky](https://img.shields.io/badge/-daniakash.com-0085FF?style=flat-square&logo=bluesky&logoColor=white)](https://bsky.app/profile/daniakash.com)
+[![LinkedIn](https://img.shields.io/badge/-Dani_Akash-0077B5?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/daniakash)
+[![Instagram](https://img.shields.io/badge/-dani__akash__-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/dani_akash_)
+[![Website](https://img.shields.io/badge/-daniakash.com-FF5722?style=flat-square&logo=astro&logoColor=white)](https://daniakash.com)
+[![GitHub](https://img.shields.io/badge/-Follow-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/DaniAkash)
 
 ---
 
-*This README was generated by [Claude Code](https://claude.com/product/claude-code) after working with DaniAkash on many projects.*
+### By the Numbers
+
+- 🗓️ On GitHub since **2014**
+- 📦 **166** public repositories
+- ⭐ **600+** stars across projects
+- 🤝 **217** followers
+
+### Philosophy
+
+> "A simple developer building AI agents for humans." — I build what I need, open source what I can, and keep shipping every day.
+
+<details>
+<summary>Random Facts</summary>
+
+- 🎮 PlayStation gamer — built an app to track my backlog
+- 🤖 Runs multiple AI coding agents concurrently
+- ☕ Powered by Chennai filter coffee
+- 📚 Technical reviewer for O'Reilly
+- 🧪 Believes in learning by building
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hi, I'm Dani 👋
 
-📍 **Chennai, India** | 🤖 **A Simple Developer Building AI Agents for Humans** | 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)**
+📍 **Chennai, India** | 🤖 **A simple developer building AI agents for humans** | 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)**
 
 ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/-JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
@@ -13,7 +13,11 @@
 ![Vite](https://img.shields.io/badge/-Vite-646CFF?style=flat-square&logo=vite&logoColor=white)
 ![Web](https://img.shields.io/badge/-Web-4285F4?style=flat-square&logo=google-chrome&logoColor=white)
 
-> A simple developer building AI agents for humans. I believe the best tools are the ones that get out of your way — and the best agents are the ones that actually do things.
+## What I do
+
+I design and develop intelligent systems — from browser-native AI agents that navigate the web autonomously, to tools that make AI practical for everyday workflows. My work sits at the intersection of browser engineering, AI agents, and developer tooling.
+
+Expert in vibe coding and prompt engineering — but I've been shipping complete products solo long before the age of AI.
 
 ## Current Projects
 
@@ -72,6 +76,13 @@
 
 ---
 
+## Beyond code
+
+I'm a regular speaker at tech communities in Chennai and Bangalore — talking about AI agents, browser internals, and building products with small teams.
+
+Latest talks:
+
+
 ### By the Numbers
 
 - 🗓️ On GitHub since **2014**
@@ -81,7 +92,7 @@
 
 ### Philosophy
 
-> "A simple developer building AI agents for humans." — I build what I need, open source what I can, and keep shipping every day.
+I build what I need, open source what I can, automate any and all boring stuff.
 
 <details>
 <summary>Random Facts</summary>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 ![React](https://img.shields.io/badge/-React-61DAFB?style=flat-square&logo=react&logoColor=black)
 ![React Native](https://img.shields.io/badge/-React_Native-61DAFB?style=flat-square&logo=react&logoColor=black)
 ![Node.js](https://img.shields.io/badge/-Node.js-339933?style=flat-square&logo=node.js&logoColor=white)
-![Python](https://img.shields.io/badge/-Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Expo](https://img.shields.io/badge/-Expo-000020?style=flat-square&logo=expo&logoColor=white)
 ![Claude](https://img.shields.io/badge/-Claude-000000?style=flat-square&logo=anthropic&logoColor=white)
+![Codex](https://img.shields.io/badge/-Codex-121212?style=flat-square&logo=openai&logoColor=white)
+![Gemini CLI](https://img.shields.io/badge/-Gemini_CLI-8E75B2?style=flat-square&logo=google&logoColor=white)
 ![Astro](https://img.shields.io/badge/-Astro-FF5D01?style=flat-square&logo=astro&logoColor=white)
 ![Vite](https://img.shields.io/badge/-Vite-646CFF?style=flat-square&logo=vite&logoColor=white)
 ![Web](https://img.shields.io/badge/-Web-4285F4?style=flat-square&logo=google-chrome&logoColor=white)
@@ -26,15 +28,6 @@ Expert in vibe coding and prompt engineering — but I've been shipping complete
 - 🧠 **[Skills](https://github.com/DaniAkash/skills)** — Teaching AI agents how to use React's useEffect correctly
 - 🧱 **[Wikiwall](https://github.com/2dapps/wikiwall)** — Collaborative wiki walls
 
-## Open Source Libraries
-
-- 📐 **[react-native-responsive-dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions)** — Responsive fontSize, height & width for React Native (473⭐)
-- ✏️ **[react-native-draftjs](https://github.com/DaniAkash/react-native-draftjs)** — Full-fledged React Native rich text editor based on Draft.js (133⭐)
-- 🔄 **[rex-state](https://github.com/DaniAkash/rex-state)** — Convert hooks into shared states between React components (30⭐)
-- 📱 **[react-native-masonry-scrollview](https://github.com/DaniAkash/react-native-masonry-scrollview)** — Pinterest-style masonry layout for React Native
-- 🔌 **[lifecycle-hooks](https://github.com/DaniAkash/lifecycle-hooks)** — React lifecycle as hooks
-- ⚡ **[vite-plugin-esm.sh](https://github.com/DaniAkash/vite-plugin-esm.sh)** — Rewrite imports with esm.sh at build time
-
 ## Previously Worked On
 
 - 🧠 **[Clarifai Node.js](https://github.com/Clarifai/clarifai-nodejs)** — Official Node.js client for the Clarifai AI platform
@@ -45,20 +38,25 @@ Expert in vibe coding and prompt engineering — but I've been shipping complete
 - 🌍 **[Pickyourtrail Travel Guide](https://pickyourtrail.com/guides/)** — Destination travel guides
 - 📦 **[React Native Toolkit](https://github.com/react-native-toolkit)** — Collection of React Native utilities and tools
 - 📖 **[React Native Docs](https://github.com/facebook/react-native-website/issues/1579)** — Contributed to React Native documentation
-- 📚 **[JavaScript By Example](https://www.oreilly.com/library/view/javascript-by-example/9781788293969/)** — Technical reviewer for O'Reilly book
+- 📚 **[JavaScript By Example](https://www.oreilly.com/library/view/javascript-by-example/9781788293969/)** — Author, O'Reilly
 
-## GitHub Activity
+## Open Source Libraries
 
-![GitHub Contribution Graph](https://ghchart.rshah.org/DaniAkash)
+- 📐 **[react-native-responsive-dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions)** — Responsive fontSize, height & width for React Native (473⭐)
+- ✏️ **[react-native-draftjs](https://github.com/DaniAkash/react-native-draftjs)** — Full-fledged React Native rich text editor based on Draft.js (133⭐)
+- 🔄 **[rex-state](https://github.com/DaniAkash/rex-state)** — Convert hooks into shared states between React components (30⭐)
+- 📱 **[react-native-masonry-scrollview](https://github.com/DaniAkash/react-native-masonry-scrollview)** — Pinterest-style masonry layout for React Native
+- 🔌 **[lifecycle-hooks](https://github.com/DaniAkash/lifecycle-hooks)** — React lifecycle as hooks
+- ⚡ **[vite-plugin-esm.sh](https://github.com/DaniAkash/vite-plugin-esm.sh)** — Rewrite imports with esm.sh at build time
 
 ## Latest Blog Posts
 
 ### From [daniakash.com](https://daniakash.com)
-- [Wrapping up 2024](https://daniakash.com/newsletter/wrapping-up-2024/)
-- [The Developer Edition](https://daniakash.com/newsletter/the-developer-edition/)
-- [Swimming Robots in Space](https://daniakash.com/newsletter/swimming-robots-in-space/)
-- [AI needs water — a lot!](https://daniakash.com/newsletter/ai-needs-water-a-lot/)
-- [$1 Trillion Dollar Goal](https://daniakash.com/newsletter/1-trillion-dollar-goal/)
+- [Less on the Client, more on the Edge](https://daniakash.com/posts/less-on-the-client/)
+- [Maintaining a React Native Library](https://daniakash.com/posts/maintaining-react-native-library/)
+- [Rex State - a handy utility to convert your hooks into shared states](https://daniakash.com/posts/rex-state/)
+- [A better Image component for React Native](https://daniakash.com/posts/better-image/)
+- [I recreated React's class component lifecycle methods with hooks](https://daniakash.com/posts/lifecycle-with-hooks/)
 
 ### From [browseros.com](https://www.browseros.com)
 - [Have a ChatGPT Subscription and a Windows PC? Now Give It a Browser.](https://www.browseros.com/blog/bring-your-own-agent)
@@ -81,14 +79,13 @@ Expert in vibe coding and prompt engineering — but I've been shipping complete
 I'm a regular speaker at tech communities in Chennai and Bangalore — talking about AI agents, browser internals, and building products with small teams.
 
 Latest talks:
+- 🎤 [AI driven Web Development with Chrome DevTools Protocol](https://www.youtube.com/live/ZThlst8vC60?si=tInBbLan4hGHrFJy) — JSLovers Chennai Meetup #9
+- 🎤 [Building an AI Agent](https://www.youtube.com/live/0NYbRQtaYhs?si=oDyUTKSDwHWI0E92) — React Meetup #96
+- 🎤 [Unlock Server Side Rendering with Nitro](https://www.youtube.com/watch?v=8SLPweAE73o) — Chennai React Meetup #15
+- 🎤 [AI for Frontend Developers](https://www.youtube.com/watch?v=_hVbeInTQKU) — React Bangalore Meetup #83
+- 🎤 [Signal Boosting](https://www.youtube.com/watch?v=Gx83aU1uT9k) — React Nexus 2023
 
-
-### By the Numbers
-
-- 🗓️ On GitHub since **2014**
-- 📦 **166** public repositories
-- ⭐ **600+** stars across projects
-- 🤝 **217** followers
+[See all talks →](https://daniakash.com/speaking)
 
 ### Philosophy
 
@@ -97,10 +94,10 @@ I build what I need, open source what I can, automate any and all boring stuff.
 <details>
 <summary>Random Facts</summary>
 
-- 🎮 PlayStation gamer — built an app to track my backlog
+- 🎮 PlayStation gamer — [built an app to track my backlog](https://github.com/DaniAkash/playstation-backlogs)
 - 🤖 Runs multiple AI coding agents concurrently
 - ☕ Powered by Chennai filter coffee
-- 📚 Technical reviewer for O'Reilly
 - 🧪 Believes in learning by building
+- 💡 Always working on random ideas
 
 </details>

--- a/daniakash.com/src/content/project/projects.json
+++ b/daniakash.com/src/content/project/projects.json
@@ -1,9 +1,72 @@
 [
   {
+    "name": "BrowserOS",
+    "description": "AI-powered browser platform that gives agents a real browser to work with. Founding Engineer building this full-time.",
+    "link": {
+      "href": "https://github.com/browseros-ai/BrowserOS",
+      "label": "github/browseros-ai"
+    },
+    "logo": "/browseros.png"
+  },
+  {
+    "name": "Inaily",
+    "description": "AI-native personal wellness app.",
+    "link": {
+      "href": "https://inaily.com/",
+      "label": "inaily.com"
+    },
+    "logo": "/inaily.png"
+  },
+  {
+    "name": "Skills",
+    "description": "Teaching AI agents how to use React's useEffect correctly — a skill that makes coding agents write better React code.",
+    "link": {
+      "href": "https://github.com/DaniAkash/skills",
+      "label": "github/DaniAkash/skills"
+    },
+    "logo": "/skills.png"
+  },
+  {
+    "name": "Wikiwall",
+    "description": "Collaborative wiki walls for building and sharing knowledge together.",
+    "link": {
+      "href": "https://github.com/2dapps/wikiwall",
+      "label": "github/2dapps/wikiwall"
+    },
+    "logo": "/wikiwall.png"
+  },
+  {
+    "name": "Clarifai Node.js",
+    "description": "Official Node.js client for the Clarifai AI platform — contributed to the core SDK.",
+    "link": {
+      "href": "https://github.com/Clarifai/clarifai-nodejs",
+      "label": "github/Clarifai"
+    },
+    "logo": "/clarifai.png"
+  },
+  {
+    "name": "Cosmo",
+    "description": "Open-source GraphQL federation by WunderGraph — contributed as an engineer on the team.",
+    "link": {
+      "href": "https://github.com/wundergraph/cosmo",
+      "label": "github/wundergraph/cosmo"
+    },
+    "logo": "/wundergraph.png"
+  },
+  {
+    "name": "Open Previews",
+    "description": "Open-source preview environments by WunderGraph for reviewing PRs visually.",
+    "link": {
+      "href": "https://github.com/wundergraph/open-previews",
+      "label": "github/wundergraph"
+    },
+    "logo": "/wundergraph.png"
+  },
+  {
     "name": "OSlash - Browser Extension",
     "description": "Shortcuts for work! Founding Engineer & team lead of the v1 of OSlash for Chrome, Safari & Firefox.",
     "info": "(product discontinued, only open source version available now)",
-    "link": { "href": "https://www.oslash.com", "label": "Get OSlash" },
+    "link": { "href": "https://www.oslash.com", "label": "oslash.com" },
     "logo": "/oslash.png"
   },
   {
@@ -14,6 +77,15 @@
       "label": "Get the app"
     },
     "logo": "/pyt.png"
+  },
+  {
+    "name": "Pickyourtrail - Travel Guide",
+    "description": "A content-rich SEO friendly Travel guide website built before the days of Gatsby & Next.js - built along with a custom in-house React Framework",
+    "link": {
+      "href": "https://pickyourtrail.com/guides/",
+      "label": "Checkout the guides"
+    },
+    "logo": "/pyt-guides.png"
   },
   {
     "name": "React Native Toolkit",
@@ -32,15 +104,6 @@
       "label": "Link to Project"
     },
     "logo": "/react-native.svg"
-  },
-  {
-    "name": "Pickyourtrail - Travel Guide",
-    "description": "A content-rich SEO friendly Travel guide website built before the days of Gatsby & Next.js - built along with a custom in-house React Framework",
-    "link": {
-      "href": "https://pickyourtrail.com/guides/",
-      "label": "Checkout the guides"
-    },
-    "logo": "/pyt-guides.png"
   },
   {
     "name": "JavaScript by Example - Book (2017)",


### PR DESCRIPTION
## Summary
- Add 7 new projects to the projects page: BrowserOS, Inaily, Skills, Wikiwall, Clarifai Node.js, Cosmo, Open Previews
- Reorder to show current active work first, followed by previous projects
- All existing projects preserved

## Test plan
- [ ] Verify all project links resolve correctly
- [ ] **Upload missing logos to assets.daniakash.com**: `browseros.png`, `inaily.png`, `skills.png`, `wikiwall.png`, `clarifai.png`, `wundergraph.png`
- [ ] Check page renders correctly after logos are added