### PR TITLE
Fix OG image URL for Twitter/LinkedIn previews

### DIFF
--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -40,7 +40,7 @@ if (!image) {
   });
   fallbackImage = image;
 }
-const ogImage = image || fallbackImage;
+const ogImage = new URL(image || fallbackImage, Astro.site).href;
 ---
 
 <html lang="en" class="dark">


### PR DESCRIPTION
## Summary
- OG image meta tags were using relative paths (`/og/slug.png`) which Twitter and LinkedIn crawlers can't resolve
- Uses `new URL()` constructor to resolve against `Astro.site` for reliable absolute URLs
- Slack was working because it resolves relative OG paths; Twitter/LinkedIn do not

## Test plan
- [ ] Deploy and verify OG image renders on [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] Verify LinkedIn post inspector shows the image
- [ ] Check existing blog posts still have working previews