### PR TITLE
fix: Add redirect from /blog/ to /posts/ for supply chain defense post

### DIFF
--- a/daniakash.com/astro.config.mjs
+++ b/daniakash.com/astro.config.mjs
@@ -9,6 +9,10 @@ import sitemap from "@astrojs/sitemap";
 // https://astro.build/config
 export default defineConfig({
   site: "https://daniakash.com",
+  redirects: {
+    "/blog/simplest-supply-chain-defense":
+      "/posts/simplest-supply-chain-defense",
+  },
   prefetch: {
     defaultStrategy: "viewport",
     prefetchAll: true,

--- a/daniakash.com/src/content/blog/simplest-supply-chain-defense.mdx
+++ b/daniakash.com/src/content/blog/simplest-supply-chain-defense.mdx
@@ -13,7 +13,7 @@ tags:
     "open-source",
     "devtools",
   ]
-canonical: https://daniakash.com/blog/simplest-supply-chain-defense
+canonical: https://daniakash.com/posts/simplest-supply-chain-defense
 ---
 
 import PostImage from "../../components/PostImage.astro";


### PR DESCRIPTION
## Summary
- Adds Astro redirect from `/blog/simplest-supply-chain-defense` to `/posts/simplest-supply-chain-defense`
- Fixes canonical URL in frontmatter to point to the correct `/posts/` route
- The `/blog/` URL was shared on Hacker News and needs to resolve

## Test plan
- [ ] Verify `/blog/simplest-supply-chain-defense` redirects to `/posts/simplest-supply-chain-defense`
- [ ] Verify the canonical meta tag points to the `/posts/` URL