### PR TITLE
docs: backfill now page history

### DIFF
--- a/daniakash.com/src/content/now/now.md
+++ b/daniakash.com/src/content/now/now.md
@@ -3,6 +3,104 @@
 
 > Based on [/now](https://sive.rs/nowff) page movement
 
+## 05 Apr, 2026
+
+- Working on browser and agent runtime infrastructure around [BrowserOS](https://github.com/browseros-ai/BrowserOS)
+
+## 31 Mar, 2026
+
+- Refreshing [daniakash.com](https://daniakash.com/), especially the homepage, projects page, and [speaking page](https://daniakash.com/speaking/)
+- Writing two blog posts.
+  - **Update** Published the posts:
+    - [When The Bill Comes Due](https://daniakash.com/posts/when-the-bill-comes-due/)
+    - [Minimum Release Age is an Underrated Supply Chain Defense](https://daniakash.com/posts/simplest-supply-chain-defense/)
+- Experimenting with agent skills via [skills](https://github.com/DaniAkash/skills) and [skill-reporter](https://github.com/DaniAkash/skill-reporter)
+- Giving a talk on [AI driven Web Development with Chrome DevTools Protocol](https://github.com/DaniAkash/ai-development-with-cdp) at [JSLovers Chennai Meetup #9](https://luma.com/kbsp31bs)
+
+## 28 Feb, 2026
+
+- Working on agent capabilities inside [BrowserOS Agent](https://github.com/browseros-ai/BrowserOS-agent)
+  - Focusing on scheduled tasks, filesystem tools, richer context, and lower-friction workflows
+
+## 31 Jan, 2026
+
+- Building a new AI browser called [BrowserOS](https://github.com/browseros-ai/BrowserOS) powered by [BrowserOS Agent](https://github.com/browseros-ai/BrowserOS-agent)
+
+## 31 Dec, 2025
+
+- Giving a talk on [Building an AI Agent](https://github.com/DaniAkash/building-an-agent) at [React Meetup #96](https://www.meetup.com/reactjs-bangalore/events/311744342/?eventOrigin=group_events_list)
+- Building [PlayStation Game Backlog Manager](https://github.com/DaniAkash/playstation-backlogs)
+- Spinning up [wordpress-bitnami](https://github.com/DaniAkash/wordpress-bitnami) image for deploying wordpress projects to [Railway](https://railway.com/)
+- Starting to spend more serious time with [BrowserOS](https://github.com/browseros-ai/BrowserOS)
+
+## 30 Nov, 2025
+
+- Preparing [Unlock Server Side Rendering with Nitro](https://github.com/DaniAkash/unlock-server-rendering) for [Chennai React Meetup #15](https://luma.com/g6aqpnb2)
+- Exploring more expressive browser/UI ideas and trying to sharpen my taste a bit
+
+## 31 Oct, 2025
+
+- Experimenting how a browser UX with native AI Agents will look like. Working example: [browser-ux](https://github.com/DaniAkash/browser-ux)
+- Researching a lot about how AI-native or browser-native interfaces should feel
+- Poking at [huggingface.js](https://github.com/huggingface/huggingface.js)
+
+## 30 Sep, 2025
+
+- Slowly Moving towards an AI first workflow
+  - Playing with ideas that later start to look a lot like a personal command center
+  - Reading and understanding how the [Gemini CLI](https://github.com/google-gemini/gemini-cli) works
+- Self-hosting some new tools on my VPS
+  - Starting a few small utility projects around self-hosted feeds, reading flows, and developer tooling
+  - Trying to build tools that help me collect, rank, and revisit information instead of just accumulating more tabs
+
+## 31 Aug, 2025
+
+- Spending most of the month in understanding AI SDK and using it with serverless platforms
+- Working on [clarifai-node-serverless](https://github.com/Clarifai/clarifai-node-serverless) to ensure the platform is accessible on modern serverless platforms and a major [Clarifai docs](https://github.com/Clarifai/docs) update
+
+## 31 Jul, 2025
+
+- Couple of smaller experiments around deployment and infra management in clarifai
+  - [clarifai-nodejs](https://github.com/Clarifai/clarifai-nodejs)
+  - [clarifai-nodejs-grpc](https://github.com/Clarifai/clarifai-nodejs-grpc)
+
+## 30 Jun, 2025
+
+- Testing [Vercel AI SDK](https://sdk.vercel.ai/) compatibility ideas in [clarifai-vercel-sdk](https://github.com/DaniAkash/clarifai-vercel-sdk)
+
+## 31 May, 2025
+
+- Continuing work on SDK, docs, and examples work for clarifai in public
+  - [clarifai-nodejs](https://github.com/Clarifai/clarifai-nodejs)
+  - [clarifai-nodejs-grpc](https://github.com/Clarifai/clarifai-nodejs-grpc)
+  - [Clarifai docs](https://github.com/Clarifai/docs)
+  - [Clarifai examples](https://github.com/Clarifai/examples)
+
+## 30 Apr, 2025
+
+- Starting to lean harder into AI developer tooling through SDK and client-library work
+- Making Clarifai platform easier for developers to use in their own node.js projects via [clarifai-nodejs](https://github.com/Clarifai/clarifai-nodejs) and [clarifai-nodejs-grpc](https://github.com/Clarifai/clarifai-nodejs-grpc)
+- Paying attention to developer experience around real model integrations
+
+## 31 Jan, 2025
+
+- Iterating on [secrets-sync](https://github.com/DaniAkash/secrets-sync), a CLI for encrypted secret and config syncing
+
+## 31 Dec, 2024
+
+- Giving [Making boring websites exciting with View Transitions API](https://daniakash.github.io/view-transitions/) talk at [Thoughtworks Geeknight 102nd edition](https://www.youtube.com/watch?v=8SLPweAE73o)
+- Giving [AI for Frontend Developers](https://github.com/DaniAkash/ai-for-frontend-developers) talk on [React Bangalore Meetup #83](https://www.meetup.com/reactjs-bangalore/events/304339695/)
+- Playing with [web-components-with-react](https://github.com/DaniAkash/web-components-with-react) and [vite-plugin-extract-vendors](https://github.com/DaniAkash/vite-plugin-extract-vendors)
+- Shipping the first version of [secrets-sync](https://github.com/DaniAkash/secrets-sync)
+
+## 30 Nov, 2024
+
+- Refreshing [daniakash.com](https://daniakash.com/) so it feels alive again instead of static
+- Experimenting with AI-powered search/chat on top of my [own content](https://github.com/DaniAkash/DaniAkash/releases/tag/v0.0.1-ai)
+- Sharing [AI for Frontend Developers](https://github.com/DaniAkash/ai-for-frontend-developers) at [React Bangalore Meetup #83](https://www.meetup.com/reactjs-bangalore/events/304339695/)
+- Experimenting with [View Transitions](https://github.com/DaniAkash/view-transitions)
+- Building a plugin to make adding esm.sh urls easier on vite project on [vite-plugin-esm.sh](https://github.com/DaniAkash/vite-plugin-esm.sh)
+
 ## 28 Oct, 2024
 
 - Test driving [Bun](https://bun.sh/) + [Elysia](https://elysiajs.com/) on [Railway](https://railway.app/)


### PR DESCRIPTION
## Summary
- replace the stale single-entry /now page with the approved monthly backfill from Oct 2024 to Apr 2026
- preserve the existing intro quote and keep the update markdown-first
- link public talks, posts, and repos that support the timeline

## Validation
- pnpm install
- pnpm build