### PR TITLE
fix: Wildcard /blog/* to /posts/* redirect and fix canonical URLs

### DIFF
--- a/daniakash.com/astro.config.mjs
+++ b/daniakash.com/astro.config.mjs
@@ -10,8 +10,7 @@ import sitemap from "@astrojs/sitemap";
 export default defineConfig({
   site: "https://daniakash.com",
   redirects: {
-    "/blog/simplest-supply-chain-defense":
-      "/posts/simplest-supply-chain-defense",
+    "/blog/[...slug]": "/posts/[...slug]",
   },
   prefetch: {
     defaultStrategy: "viewport",

--- a/daniakash.com/src/content.config.ts
+++ b/daniakash.com/src/content.config.ts
@@ -44,7 +44,7 @@ const blog = defineCollection({
     subtitle: z.string(),
     date: z.string(),
     tags: z.array(z.string()).max(9),
-    canonical: z.string(),
+    canonical: z.string().optional(),
   }),
 });
 

--- a/daniakash.com/src/content/blog/simplest-supply-chain-defense.mdx
+++ b/daniakash.com/src/content/blog/simplest-supply-chain-defense.mdx
@@ -13,7 +13,6 @@ tags:
     "open-source",
     "devtools",
   ]
-canonical: https://daniakash.com/posts/simplest-supply-chain-defense
 ---
 
 import PostImage from "../../components/PostImage.astro";

--- a/daniakash.com/src/content/blog/when-the-bill-comes-due.mdx
+++ b/daniakash.com/src/content/blog/when-the-bill-comes-due.mdx
@@ -14,7 +14,6 @@ tags:
     "openai",
     "infrastructure",
   ]
-canonical: https://daniakash.com/posts/when-the-bill-comes-due
 ---
 
 import PostImage from "../../components/PostImage.astro";

--- a/daniakash.com/src/content/blog/when-the-bill-comes-due.mdx
+++ b/daniakash.com/src/content/blog/when-the-bill-comes-due.mdx
@@ -14,7 +14,7 @@ tags:
     "openai",
     "infrastructure",
   ]
-canonical: https://daniakash.com/blog/when-the-bill-comes-due
+canonical: https://daniakash.com/posts/when-the-bill-comes-due
 ---
 
 import PostImage from "../../components/PostImage.astro";

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -23,6 +23,7 @@ const { Content } = await render(post);
 
 const dateValue = getDateValue(post.data.date);
 const dateDisplay = getDateDisplay(post.data.date);
+const canonical = post.data.canonical || new URL(`/posts/${post.id}`, Astro.site).href;
 const image = `/og/${post.id}.png`;
 await getOGImage({
   title: post.data.title,
@@ -35,7 +36,7 @@ await getOGImage({
   title={post.data.title}
   description={post.data.subtitle}
   keywords={post.data.tags}
-  canonical={post.data.canonical}
+  canonical={canonical}
   image={image}
 >
   <ArticleContainer>


### PR DESCRIPTION
## Summary
- Replaces the single-post redirect with a wildcard `"/blog/[...slug]": "/posts/[...slug]"` so ALL `/blog/*` URLs redirect to `/posts/*`
- Fixes canonical URL in `when-the-bill-comes-due` frontmatter from `/blog/` to `/posts/`
- Supersedes #13 (which only handled one post)

## Context
Blog posts are served at `/posts/<slug>` but canonical URLs and shared links sometimes use `/blog/<slug>`. This ensures any `/blog/` URL redirects correctly.

## Test plan
- [ ] Verify `/blog/simplest-supply-chain-defense` redirects to `/posts/simplest-supply-chain-defense`
- [ ] Verify `/blog/when-the-bill-comes-due` redirects to `/posts/when-the-bill-comes-due`
- [ ] Verify `/blog/prototype-pollution` redirects to `/posts/prototype-pollution`
- [ ] Verify canonical meta tag on when-the-bill-comes-due points to `/posts/`