### PR TITLE
feat(seo): add canonicals, breadcrumbs, and structured data

### DIFF
--- a/daniakash.com/package.json
+++ b/daniakash.com/package.json
@@ -25,11 +25,13 @@
     "@react-spring/web": "^10.0.3",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.0.8",
+    "astro-seo-schema": "^6.0.0",
     "clsx": "^2.1.1",
     "cobe": "^2.0.1",
     "motion": "^12.38.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "schema-dts": "^2.0.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2"

--- a/daniakash.com/pnpm-lock.yaml
+++ b/daniakash.com/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       astro:
         specifier: ^6.0.8
         version: 6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3)
+      astro-seo-schema:
+        specifier: ^6.0.0
+        version: 6.0.0(astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3))(schema-dts@2.0.0(typescript@6.0.2))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -53,6 +56,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      schema-dts:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@6.0.2)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1190,6 +1196,12 @@ packages:
     resolution: {integrity: sha512-ArkZbr9yLPSTLDv1rBADYNMRNVyYi/opbFAOfsLDbHQyfDI4sUBg4MtuRrbwDCqfCsfUwKv8421VenZJaoPKFA==}
     peerDependencies:
       astro: ^6.0.0
+
+  astro-seo-schema@6.0.0:
+    resolution: {integrity: sha512-6Etg+9zu7XdlUa40BIZrZP3vd+lReeJ1rNgT8Jer+1bPyGdrA/itQwJOhIkX+t5PadVwTmpt6xZouDycrZys6w==}
+    peerDependencies:
+      astro: ^6.0.0
+      schema-dts: ^1.1.0
 
   astro@6.0.8:
     resolution: {integrity: sha512-DCPeb8GKOoFWh+8whB7Qi/kKWD/6NcQ9nd1QVNzJFxgHkea3WYrNroQRq4whmBdjhkYPTLS/1gmUAl2iA2Es2g==}
@@ -2364,6 +2376,15 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-dts-lib@1.0.0:
+    resolution: {integrity: sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+
+  schema-dts@2.0.0:
+    resolution: {integrity: sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3861,6 +3882,11 @@ snapshots:
   astro-seo-meta@6.0.0(astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3)):
     dependencies:
       astro: 6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3)
+
+  astro-seo-schema@6.0.0(astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3))(schema-dts@2.0.0(typescript@6.0.2)):
+    dependencies:
+      astro: 6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3)
+      schema-dts: 2.0.0(typescript@6.0.2)
 
   astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@6.0.2)(yaml@2.8.3):
     dependencies:
@@ -5454,6 +5480,16 @@ snapshots:
   sax@1.6.0: {}
 
   scheduler@0.27.0: {}
+
+  schema-dts-lib@1.0.0(typescript@6.0.2):
+    dependencies:
+      typescript: 6.0.2
+
+  schema-dts@2.0.0(typescript@6.0.2):
+    dependencies:
+      schema-dts-lib: 1.0.0(typescript@6.0.2)
+    transitivePeerDependencies:
+      - typescript
 
   semver@6.3.1: {}
 

--- a/daniakash.com/src/constants/seo.ts
+++ b/daniakash.com/src/constants/seo.ts
@@ -1,0 +1,14 @@
+export const FALLBACK_DESCRIPTION =
+  "Dani Akash — AI Engineer, speaker, and open source contributor. Writing about AI, JavaScript, React Native, and the modern web.";
+
+export const SEGMENT_LABELS: Record<string, string> = {
+  about: "About",
+  blog: "Blog",
+  posts: "Blog",
+  newsletter: "Newsletter",
+  projects: "Projects",
+  speaking: "Speaking",
+  uses: "Uses",
+  now: "Now",
+  resume: "Resume",
+};

--- a/daniakash.com/src/constants/seo.ts
+++ b/daniakash.com/src/constants/seo.ts
@@ -1,5 +1,5 @@
 export const FALLBACK_DESCRIPTION =
-  "Dani Akash — AI Engineer, speaker, and open source contributor. Writing about AI, JavaScript, React Native, and the modern web.";
+  "Dani Akash | AI Engineer, speaker, and open source contributor. Writing about AI, JavaScript, React Native, and the modern web.";
 
 export const SEGMENT_LABELS: Record<string, string> = {
   about: "About",

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -2,9 +2,11 @@
 import "../styles/global.css";
 import { ClientRouter } from "astro:transitions";
 import { Seo } from "astro-seo-meta";
+import { Schema } from "astro-seo-schema";
 import Nav from "../components/Nav.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { ASSET_PREFIX } from "../constants/asset-prefix";
+import { FALLBACK_DESCRIPTION, SEGMENT_LABELS } from "../constants/seo";
 import { getOGImage } from "../utils/getOGImage";
 
 interface Props {
@@ -31,15 +33,45 @@ if (!image) {
   const ogPath = `/og/general/${encodeURI(Astro.url.pathname.split("/").join("-"))}.png`;
   await getOGImage({
     title: title || "Dani Akash",
-    description:
-      description ||
-      "Empowering ideas and inspiring creativity – Discover more at daniakash.com",
+    description: description || FALLBACK_DESCRIPTION,
     path: ogPath,
     cover: `${ASSET_PREFIX}/image-3.jpg`,
   });
   fallbackImage = ogPath;
 }
 const ogImage = new URL(image || fallbackImage, Astro.site).href;
+
+// --- Structured Data ---
+const siteUrl = Astro.site?.href || "https://daniakash.com/";
+const pathSegments = Astro.url.pathname.split("/").filter(Boolean);
+
+const breadcrumbItems: Array<{ name: string; url: string }> = [
+  { name: "Home", url: siteUrl },
+];
+
+if (pathSegments.length > 0) {
+  const firstSegment = pathSegments[0] as string;
+  const parentLabel = SEGMENT_LABELS[firstSegment] || firstSegment;
+  const parentPath = firstSegment === "posts" ? "/blog/" : `/${firstSegment}/`;
+
+  if (pathSegments.length > 1) {
+    breadcrumbItems.push({
+      name: parentLabel,
+      url: new URL(parentPath, siteUrl).href,
+    });
+    breadcrumbItems.push({
+      name: title || (pathSegments[pathSegments.length - 1] as string),
+      url: new URL(Astro.url.pathname, siteUrl).href,
+    });
+  } else {
+    breadcrumbItems.push({
+      name: parentLabel,
+      url: new URL(Astro.url.pathname, siteUrl).href,
+    });
+  }
+}
+
+const isHomePage = Astro.url.pathname === "/";
 ---
 
 <html lang="en" class="dark">
@@ -69,8 +101,7 @@ const ogImage = new URL(image || fallbackImage, Astro.site).href;
     <meta name="generator" content={Astro.generator} />
     <Seo
       title={title ? `${title} | Dani Akash` : "Dani Akash"}
-      description={description ||
-        "Empowering ideas and inspiring creativity – Discover more at daniakash.com"}
+      description={description || FALLBACK_DESCRIPTION}
       keywords={keywords || [
         "Dani Akash",
         "Personal Blog",
@@ -92,7 +123,36 @@ const ogImage = new URL(image || fallbackImage, Astro.site).href;
         image: ogImage,
       }}
     />
-    {canonical ? <link rel="canonical" href={canonical} /> : null}
+    <link rel="canonical" href={canonical || new URL(Astro.url.pathname, Astro.site).href} />
+    <Schema
+      item={{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: breadcrumbItems.map((item, index) => ({
+          "@type": "ListItem" as const,
+          position: index + 1,
+          name: item.name,
+          item: item.url,
+        })),
+      }}
+    />
+    {isHomePage && (
+      <Schema
+        item={{
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          name: "Dani Akash",
+          url: siteUrl,
+          description: FALLBACK_DESCRIPTION,
+          author: {
+            "@type": "Person",
+            name: "Dani Akash",
+            url: siteUrl,
+            jobTitle: "AI Engineer",
+          },
+        }}
+      />
+    )}
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link
       rel="alternate"

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -123,7 +123,7 @@ const isHomePage = Astro.url.pathname === "/";
         image: ogImage,
       }}
     />
-    <link rel="canonical" href={canonical || new URL(Astro.url.pathname, Astro.site).href} />
+    <link rel="canonical" href={canonical || new URL(Astro.url.pathname, siteUrl).href} />
     <Schema
       item={{
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- **Self-referencing canonical URLs** on all 35 pages (explicit canonicals from blog/newsletter still take precedence)
- **BreadcrumbList JSON-LD** on every page via `astro-seo-schema` — `/posts/*` maps under "Blog" parent for correct hierarchy
- **WebSite JSON-LD** with Person author on homepage only
- **Improved fallback meta description** — replaces generic copy with specific AI Engineer/topics description
- **SEO constants** extracted to `src/constants/seo.ts` for reuse in future schema additions

## Dependencies added
- `astro-seo-schema` — typed `<Schema>` component for JSON-LD
- `schema-dts` — TypeScript definitions for schema.org vocabulary

## Test plan
- [ ] `pnpm build` succeeds (35 pages)
- [ ] All pages have `<link rel="canonical">` in HTML source
- [ ] Homepage has both BreadcrumbList and WebSite JSON-LD
- [ ] About page has BreadcrumbList (Home > About) but no WebSite schema
- [ ] Blog post has BreadcrumbList (Home > Blog > Post Title)
- [ ] Blog posts with explicit canonical use their value, not the computed one
- [ ] Pages without custom description show new fallback in meta tags
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)