### PR TITLE
feat(seo): add and optimize meta descriptions for all pages

### DIFF
--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -16,7 +16,7 @@ const destinationsData = (await getCollection("destinations"))[0]!;
 const destinations = destinationsData.data.items;
 ---
 
-<MainLayout title="About" description="About Dani Akash — AI Engineer, Builder, Speaker. Based in Chennai, India.">
+<MainLayout title="About" description="Dani Akash | AI Engineer, builder, and speaker based in Chennai, India. Building AI agents and writing about JavaScript, React Native, and the web.">
   <main class="about-page">
     <div class="mx-auto max-w-[1200px] px-6">
       <div class="about-grid">

--- a/daniakash.com/src/pages/blog.astro
+++ b/daniakash.com/src/pages/blog.astro
@@ -16,7 +16,7 @@ for (const post of posts) {
 const years = [...postsByYear.keys()].sort((a, b) => b - a);
 ---
 
-<MainLayout title="Blog">
+<MainLayout title="Blog" description="Articles on AI, JavaScript, React Native, and building for the web.">
   <!-- Header -->
   <header class="pb-12 pt-[120px]">
     <p class="mb-6 font-mono text-[11px] uppercase tracking-[1.65px] text-muted-foreground">

--- a/daniakash.com/src/pages/newsletter.astro
+++ b/daniakash.com/src/pages/newsletter.astro
@@ -18,7 +18,7 @@ const years = [...issuesByYear.keys()].sort((a, b) => b - a);
 
 <MainLayout
   title="Newsletter"
-  description="Thoughts delivered straight to your inbox, with zero spam (I promise)."
+  description="Dani Akash's newsletter on AI, tech, science, and the web | delivered to your inbox, zero spam."
 >
   <div class="mx-auto max-w-[720px] pb-20 pt-[120px]">
     <!-- Header -->

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -28,9 +28,20 @@ export const getStaticPaths = (async () => {
   });
 }) satisfies GetStaticPaths;
 
-const description =
-  "Thoughts on AI, tech, science, and the web — delivered to your inbox.";
 const { content, dateDisplay, title, canonical, prev, next } = Astro.props;
+
+// Extract unique description from issue content, fallback to generic
+const fallbackDescription =
+  "Dani Akash's newsletter on AI, tech, science, and the web | delivered to your inbox.";
+const plainText = content
+  .replace(/<[^>]+>/g, " ")
+  .replace(/&[a-z]+;/gi, " ")
+  .replace(/\s+/g, " ")
+  .trim();
+const description =
+  plainText.length > 10
+    ? plainText.substring(0, 150).replace(/\s+\S*$/, "") + "..."
+    : fallbackDescription;
 const { slug } = Astro.params;
 const image = `/og/newsletter/${slug}.png`;
 await getOGImage({

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -39,9 +39,11 @@ const plainText = content
   .replace(/\s+/g, " ")
   .trim();
 const description =
-  plainText.length > 10
+  plainText.length > 150
     ? plainText.substring(0, 150).replace(/\s+\S*$/, "") + "..."
-    : fallbackDescription;
+    : plainText.length > 10
+      ? plainText
+      : fallbackDescription;
 const { slug } = Astro.params;
 const image = `/og/newsletter/${slug}.png`;
 await getOGImage({

--- a/daniakash.com/src/pages/now.astro
+++ b/daniakash.com/src/pages/now.astro
@@ -5,7 +5,7 @@ import MainLayout from "../layouts/MainLayout.astro";
 const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
 ---
 
-<MainLayout title="Now">
+<MainLayout title="Now" description="What Dani Akash is working on right now | current projects, talks, and interests.">
   <div class="mx-auto max-w-[900px] pt-[120px] pb-20">
     <div class="md-editor">
       <div class="md-editor__titlebar">

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -8,7 +8,7 @@ const items = projects.data.items;
 
 <MainLayout
   title="Projects"
-  description="Things I've built — from browser extensions to open source libraries to AI agents."
+  description="Projects by Dani Akash | from browser extensions to open source libraries to AI agents."
 >
   <!-- Factory Background — fixed, masked, behind content -->
   <div class="factory-fixed">

--- a/daniakash.com/src/pages/resume.astro
+++ b/daniakash.com/src/pages/resume.astro
@@ -6,7 +6,7 @@ const resumeData = (await getCollection("resume"))[0]!.data;
 const { tagline, about, skills, jobs, community, education } = resumeData;
 ---
 
-<MainLayout title="Resume">
+<MainLayout title="Resume" description="Professional experience and skills of Dani Akash | AI Engineer with expertise in React Native, JavaScript, and web development.">
   <article class="mx-auto max-w-[800px] pt-[120px] pb-20" id="article">
 
     <!-- Header -->

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -10,7 +10,7 @@ const events = (await getCollection("speaking")).sort(
 );
 ---
 
-<MainLayout title="Speaking">
+<MainLayout title="Speaking" description="25+ talks on AI, JavaScript, React Native, and the web at conferences and community meetups since 2017.">
   <!-- Header -->
   <header class="pb-12 pt-[120px]">
     <p


### PR DESCRIPTION
## Summary
- **Add missing descriptions** to 4 pages: blog, speaking, resume, now
- **Optimize existing descriptions** on 3 pages: about, newsletter, projects (remove emdashes, add name/keywords, use pipe separator)
- **Generate unique descriptions** for all 10 newsletter issues by extracting first ~150 chars from issue content (replaces single hardcoded string shared by all issues)

Every page on the site now has a unique, keyword-relevant meta description.

## Before & After

| Page | Before | After |
|------|--------|-------|
| `/blog/` | Generic fallback | "Articles on AI, JavaScript, React Native, and building for the web." |
| `/speaking/` | Generic fallback | "25+ talks on AI, JavaScript, React Native, and the web at conferences and community meetups since 2017." |
| `/resume/` | Generic fallback | "Professional experience and skills of Dani Akash \| AI Engineer..." |
| `/now/` | Generic fallback | "What Dani Akash is working on right now \| current projects, talks, and interests." |
| `/about/` | "About Dani Akash — AI Engineer..." | "Dani Akash \| AI Engineer, builder, and speaker based in Chennai..." |
| `/newsletter/` | "Thoughts delivered straight to your inbox..." | "Dani Akash's newsletter on AI, tech, science, and the web \| ..." |
| `/projects/` | "Things I've built —..." | "Projects by Dani Akash \| from browser extensions..." |
| Newsletter issues | Same string for all 10 | Unique excerpt per issue |

## Test plan
- [ ] `pnpm build` succeeds (35 pages)
- [ ] All 9 static pages have unique descriptions (no two identical)
- [ ] All 10 newsletter issues have unique descriptions (no two identical)
- [ ] No page uses the generic fallback except homepage (intentional)
- [ ] Blog posts still use their `post.data.subtitle` descriptions
- [ ] `/uses/` unchanged: "Hardware, software, and tools Dani Akash uses for development."