### PR TITLE
feat(seo): add Person schema with Knowledge Panel integration

### DIFF
--- a/daniakash.com/astro.config.mjs
+++ b/daniakash.com/astro.config.mjs
@@ -6,10 +6,11 @@ import { defineConfig } from "astro/config";
 import metaTags from "astro-meta-tags";
 import robotsTxt from "astro-robots-txt";
 import rehypeExternalLinks from "rehype-external-links";
+import { SITE_URL } from "./src/constants/seo.ts";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://daniakash.com",
+  site: SITE_URL,
   redirects: {
     "/blog/[...slug]": "/posts/[...slug]",
   },

--- a/daniakash.com/src/constants/seo.ts
+++ b/daniakash.com/src/constants/seo.ts
@@ -1,4 +1,9 @@
-/** Stable entity URI for the Person — used across all schemas to link author references */
+/**
+ * Stable entity URI for the Person — used across all schemas to link author references.
+ * Intentionally hardcoded to the production origin: this is an entity identifier (not a page URL),
+ * so it must remain constant across all environments (preview, staging, production).
+ * Derived from the same origin as `site` in astro.config.mjs.
+ */
 export const PERSON_ENTITY_ID = "https://daniakash.com/#person";
 
 export const FALLBACK_DESCRIPTION =

--- a/daniakash.com/src/constants/seo.ts
+++ b/daniakash.com/src/constants/seo.ts
@@ -1,10 +1,8 @@
-/**
- * Stable entity URI for the Person — used across all schemas to link author references.
- * Intentionally hardcoded to the production origin: this is an entity identifier (not a page URL),
- * so it must remain constant across all environments (preview, staging, production).
- * Derived from the same origin as `site` in astro.config.mjs.
- */
-export const PERSON_ENTITY_ID = "https://daniakash.com/#person";
+/** Canonical site URL — single source of truth, also used by astro.config.mjs */
+export const SITE_URL = "https://daniakash.com";
+
+/** Stable entity URI for the Person — used across all schemas to link author references */
+export const PERSON_ENTITY_ID = `${SITE_URL}/#person`;
 
 export const FALLBACK_DESCRIPTION =
   "Dani Akash | AI Engineer, speaker, and open source contributor. Writing about AI, JavaScript, React Native, and the modern web.";

--- a/daniakash.com/src/constants/seo.ts
+++ b/daniakash.com/src/constants/seo.ts
@@ -1,3 +1,6 @@
+/** Stable entity URI for the Person — used across all schemas to link author references */
+export const PERSON_ENTITY_ID = "https://daniakash.com/#person";
+
 export const FALLBACK_DESCRIPTION =
   "Dani Akash | AI Engineer, speaker, and open source contributor. Writing about AI, JavaScript, React Native, and the modern web.";
 

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -6,7 +6,7 @@ import { Schema } from "astro-seo-schema";
 import Nav from "../components/Nav.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import { ASSET_PREFIX } from "../constants/asset-prefix";
-import { FALLBACK_DESCRIPTION, SEGMENT_LABELS } from "../constants/seo";
+import { FALLBACK_DESCRIPTION, PERSON_ENTITY_ID, SEGMENT_LABELS } from "../constants/seo";
 import { getOGImage } from "../utils/getOGImage";
 
 interface Props {
@@ -150,6 +150,7 @@ const isHomePage = Astro.url.pathname === "/";
           description: FALLBACK_DESCRIPTION,
           author: {
             "@type": "Person",
+            "@id": PERSON_ENTITY_ID,
             name: "Dani Akash",
             url: siteUrl,
             jobTitle: "AI Engineer",

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -152,7 +152,7 @@ const isHomePage = Astro.url.pathname === "/";
             "@type": "Person",
             "@id": PERSON_ENTITY_ID,
             name: "Dani Akash",
-            url: siteUrl,
+            url: new URL("/about/", siteUrl).href,
             jobTitle: "AI Engineer",
           },
         }}

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -7,8 +7,12 @@ import InstagramIcon from "../components/icons/InstagramIcon.astro";
 import LinkedinIcon from "../components/icons/LinkedinIcon.astro";
 import MailDarkIcon from "../components/icons/MailDarkIcon.astro";
 import TwitterIcon from "../components/icons/TwitterIcon.astro";
+import { Schema } from "astro-seo-schema";
+import { ASSET_PREFIX } from "../constants/asset-prefix";
+import { PERSON_ENTITY_ID } from "../constants/seo";
 import MainLayout from "../layouts/MainLayout.astro";
 
+const siteUrl = Astro.site?.href || "https://daniakash.com/";
 const about = (await getCollection("about"))[0]!;
 const { Content } = await render(about);
 const social = (await getCollection("social"))[0]!;
@@ -17,6 +21,46 @@ const destinations = destinationsData.data.items;
 ---
 
 <MainLayout title="About" description="Dani Akash | AI Engineer, builder, and speaker based in Chennai, India. Building AI agents and writing about JavaScript, React Native, and the web.">
+  <Schema
+    item={{
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "@id": PERSON_ENTITY_ID,
+      name: "Dani Akash",
+      url: siteUrl,
+      image: `${ASSET_PREFIX}/avatar.jpg`,
+      jobTitle: "AI Engineer",
+      description:
+        "AI Engineer, speaker, and open source contributor based in Chennai, India. Building AI agents and writing about JavaScript, React Native, and the web.",
+      nationality: {
+        "@type": "Country",
+        name: "India",
+      },
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Chennai",
+        addressCountry: "IN",
+      },
+      sameAs: [
+        social.data.github,
+        social.data.twitter,
+        social.data.bluesky,
+        social.data.linkedIn,
+        social.data.instagram,
+        "https://www.google.com/search?kgmid=/g/11gbhlgy7j",
+      ],
+      knowsAbout: [
+        "Artificial Intelligence",
+        "AI Agents",
+        "JavaScript",
+        "TypeScript",
+        "React Native",
+        "React",
+        "Web Development",
+        "Open Source",
+      ],
+    }}
+  />
   <main class="about-page">
     <div class="mx-auto max-w-[1200px] px-6">
       <div class="about-grid">

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -27,7 +27,7 @@ const destinations = destinationsData.data.items;
       "@type": "Person",
       "@id": PERSON_ENTITY_ID,
       name: "Dani Akash",
-      url: siteUrl,
+      url: new URL("/about/", siteUrl).href,
       image: `${ASSET_PREFIX}/avatar.jpg`,
       jobTitle: "AI Engineer",
       description:

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { Schema } from "astro-seo-schema";
+import { PERSON_ENTITY_ID } from "../../constants/seo";
 import MainLayout from "../../layouts/MainLayout.astro";
 import { getDateDisplay } from "../../utils/getDateDisplay";
 import { getDateValue } from "../../utils/getDateValue";
@@ -51,12 +52,14 @@ await getOGImage({
       datePublished: dateISO,
       author: {
         "@type": "Person",
+        "@id": PERSON_ENTITY_ID,
         name: "Dani Akash",
         url: new URL("/about/", siteUrl).href,
         jobTitle: "AI Engineer",
       },
       publisher: {
         "@type": "Person",
+        "@id": PERSON_ENTITY_ID,
         name: "Dani Akash",
         url: siteUrl,
       },

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -61,7 +61,7 @@ await getOGImage({
         "@type": "Person",
         "@id": PERSON_ENTITY_ID,
         name: "Dani Akash",
-        url: siteUrl,
+        url: new URL("/about/", siteUrl).href,
       },
       mainEntityOfPage: {
         "@type": "WebPage",


### PR DESCRIPTION
## Summary
- **Person JSON-LD** on about page with full entity definition: `@id`, `image`, `jobTitle`, `nationality`, `address`, `sameAs`, `knowsAbout`
- **Knowledge Panel connection** via kgmid `/g/11gbhlgy7j` in `sameAs` array — links structured data to existing Google Knowledge Panel
- **`@id` cross-referencing** — `PERSON_ENTITY_ID` constant (`https://daniakash.com/#person`) added to BlogPosting author/publisher and WebSite author, creating a connected entity graph

## Knowledge Panel Impact
| Signal | Expected Effect |
|--------|----------------|
| `jobTitle: "AI Engineer"` | May update panel title from "Writer" |
| `sameAs` with kgmid URL | Strengthens panel ownership |
| `sameAs` with 5 social profiles | May add missing profiles to panel |
| `image` with avatar URL | May influence panel photo |
| `@id` cross-refs from blog posts | Connects blog authorship to panel entity |

## Files Changed (4)
- `src/constants/seo.ts` — new `PERSON_ENTITY_ID` constant
- `src/pages/about.astro` — Person JSON-LD schema
- `src/pages/posts/[...slug].astro` — `@id` in BlogPosting author/publisher
- `src/layouts/MainLayout.astro` — `@id` in WebSite author

## Test plan
- [ ] `pnpm build` succeeds (35 pages)
- [ ] About page has Person JSON-LD with all fields (6 sameAs, 8 knowsAbout, kgmid)
- [ ] Blog posts have `@id: "https://daniakash.com/#person"` in author and publisher
- [ ] Homepage WebSite has `@id` in author
- [ ] No standalone Person schema on non-about pages
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)