### PR TITLE
fix: make all scripts survive Astro View Transition navigation

### DIFF
--- a/daniakash.com/src/pages/blog.astro
+++ b/daniakash.com/src/pages/blog.astro
@@ -117,39 +117,46 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
   }
 </style>
 
-<script>
-  // Align progress track to the centre column and animate fill
-  function initTimeline() {
-    const comp = document.getElementById("timelineComponent");
-    const bar = document.getElementById("progressBar");
-    const track = document.getElementById("progressTrack");
+<script is:inline>
+  document.addEventListener("astro:page-load", function () {
+    var comp = document.getElementById("timelineComponent");
+    var bar = document.getElementById("progressBar");
+    var track = document.getElementById("progressTrack");
     if (!comp || !bar || !track) return;
 
+    if (window.__timelineCleanup) window.__timelineCleanup();
+
     function alignProgress() {
-      const circle = comp!.querySelector(".sticky.rounded-full");
+      var circle = comp.querySelector(".sticky.rounded-full");
       if (circle) {
-        const compRect = comp!.getBoundingClientRect();
-        const circleRect = circle.getBoundingClientRect();
-        const left =
+        var compRect = comp.getBoundingClientRect();
+        var circleRect = circle.getBoundingClientRect();
+        var left =
           circleRect.left + circleRect.width / 2 - compRect.left - 1;
-        track!.style.left = left + "px";
+        track.style.left = left + "px";
       }
     }
     alignProgress();
-    window.addEventListener("resize", alignProgress);
 
+    var resizeHandler = function () {
+      alignProgress();
+    };
+    window.addEventListener("resize", resizeHandler);
+
+    var animId;
     function updateProgress() {
-      const rect = comp!.getBoundingClientRect();
-      const viewportMid = window.innerHeight * 0.5;
-      const fillPx = viewportMid - rect.top;
-      bar!.style.height =
+      var rect = comp.getBoundingClientRect();
+      var viewportMid = window.innerHeight * 0.5;
+      var fillPx = viewportMid - rect.top;
+      bar.style.height =
         Math.max(0, Math.min(fillPx, rect.height)) + "px";
-      requestAnimationFrame(updateProgress);
+      animId = requestAnimationFrame(updateProgress);
     }
-    requestAnimationFrame(updateProgress);
-  }
+    animId = requestAnimationFrame(updateProgress);
 
-  // Run on page load and after view transitions
-  initTimeline();
-  document.addEventListener("astro:after-swap", initTimeline);
+    window.__timelineCleanup = function () {
+      cancelAnimationFrame(animId);
+      window.removeEventListener("resize", resizeHandler);
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/blog.astro
+++ b/daniakash.com/src/pages/blog.astro
@@ -119,12 +119,12 @@ const years = [...postsByYear.keys()].sort((a, b) => b - a);
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {
+    if (window.__timelineCleanup) window.__timelineCleanup();
+
     var comp = document.getElementById("timelineComponent");
     var bar = document.getElementById("progressBar");
     var track = document.getElementById("progressTrack");
     if (!comp || !bar || !track) return;
-
-    if (window.__timelineCleanup) window.__timelineCleanup();
 
     function alignProgress() {
       var circle = comp.querySelector(".sticky.rounded-full");

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -170,10 +170,10 @@ await getOGImage({
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
+
     var article = document.getElementById("article");
     if (!article) return;
-
-    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
 
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -169,9 +169,11 @@ await getOGImage({
 </style>
 
 <script is:inline>
-  (function () {
+  document.addEventListener("astro:page-load", function () {
     var article = document.getElementById("article");
     if (!article) return;
+
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
 
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();
@@ -186,6 +188,7 @@ await getOGImage({
     container.appendChild(bar);
     document.body.appendChild(container);
 
+    var animId;
     function update() {
       var rect = article.getBoundingClientRect();
       var total = rect.height - window.innerHeight;
@@ -195,8 +198,14 @@ await getOGImage({
       }
       var pct = Math.max(0, Math.min(100, (-rect.top / total) * 100));
       bar.style.width = pct + "%";
-      requestAnimationFrame(update);
+      animId = requestAnimationFrame(update);
     }
-    requestAnimationFrame(update);
-  })();
+    animId = requestAnimationFrame(update);
+
+    window.__readingProgressCleanup = function () {
+      cancelAnimationFrame(animId);
+      var el = document.getElementById("readingProgress");
+      if (el) el.remove();
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/now.astro
+++ b/daniakash.com/src/pages/now.astro
@@ -228,17 +228,19 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
   }
 </style>
 
-<script is:inline data-astro-rerun src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"
+<script is:inline src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"
 ></script>
-<script is:inline data-astro-rerun
+<script is:inline
   src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-markdown.min.js"
 ></script>
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
 />
-<script is:inline data-astro-rerun>
-  (function () {
+<script is:inline>
+  document.addEventListener("astro:page-load", function () {
+    if (window.__nowEditorCleanup) window.__nowEditorCleanup();
+
     var body = document.querySelector(".md-editor__body");
     if (!body) return;
 
@@ -249,10 +251,17 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
     var code = body.querySelector("code");
     if (!code) return;
 
+    var pendingInterval = null;
+    var pendingTimeout = null;
+    var buildTimeout = null;
+
     function runHighlight() {
       if (typeof Prism !== "undefined") Prism.highlightAll();
 
-      setTimeout(function () {
+      buildTimeout = setTimeout(function () {
+        // Verify body is still in the document (user may have navigated away)
+        if (!document.contains(body)) return;
+
         var freshCode = body.querySelector("code");
         if (!freshCode) return;
 
@@ -301,7 +310,6 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
       }, 150);
     }
 
-    // Wait for both Prism core AND markdown language component to be loaded
     function isPrismReady() {
       return typeof Prism !== "undefined" && Prism.languages && Prism.languages.markdown;
     }
@@ -309,15 +317,23 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
     if (isPrismReady()) {
       runHighlight();
     } else {
-      var checkInterval = setInterval(function () {
+      pendingInterval = setInterval(function () {
         if (isPrismReady()) {
-          clearInterval(checkInterval);
+          clearInterval(pendingInterval);
+          pendingInterval = null;
           runHighlight();
         }
       }, 50);
-      setTimeout(function () {
-        clearInterval(checkInterval);
+      pendingTimeout = setTimeout(function () {
+        if (pendingInterval) clearInterval(pendingInterval);
+        pendingInterval = null;
       }, 5000);
     }
-  })();
+
+    window.__nowEditorCleanup = function () {
+      if (pendingInterval) clearInterval(pendingInterval);
+      if (pendingTimeout) clearTimeout(pendingTimeout);
+      if (buildTimeout) clearTimeout(buildTimeout);
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/now.astro
+++ b/daniakash.com/src/pages/now.astro
@@ -239,17 +239,17 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
   href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
 />
 <script is:inline>
-  function initNowEditor() {
+  document.addEventListener("astro:page-load", function () {
     var body = document.querySelector(".md-editor__body");
     if (!body) return;
 
-    // Skip if already initialized (table already exists)
-    if (body.querySelector(".md-editor__table")) return;
+    // Remove previous table to allow re-initialization on VT navigation
+    var existingTable = body.querySelector(".md-editor__table");
+    if (existingTable) existingTable.remove();
 
     var code = body.querySelector("code");
     if (!code) return;
 
-    // Ensure Prism is loaded before highlighting
     function runHighlight() {
       if (typeof Prism !== "undefined") Prism.highlightAll();
 
@@ -286,7 +286,6 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
         if (pre) pre.remove();
         body.appendChild(table);
 
-        // Make markdown links clickable
         body.querySelectorAll(".token.url").forEach(function (token) {
           var text = token.textContent;
           var match = text.match(/\(([^)]+)\)/);
@@ -306,19 +305,15 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
     if (typeof Prism !== "undefined") {
       runHighlight();
     } else {
-      // Prism not loaded yet — wait for it
       var checkInterval = setInterval(function () {
         if (typeof Prism !== "undefined") {
           clearInterval(checkInterval);
           runHighlight();
         }
       }, 50);
-      // Timeout after 3s
       setTimeout(function () {
         clearInterval(checkInterval);
       }, 3000);
     }
-  }
-
-  document.addEventListener("astro:page-load", initNowEditor);
+  });
 </script>

--- a/daniakash.com/src/pages/now.astro
+++ b/daniakash.com/src/pages/now.astro
@@ -228,18 +228,17 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
   }
 </style>
 
-<script is:inline src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"
+<script is:inline data-astro-rerun src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"
 ></script>
-<script
-  is:inline
+<script is:inline data-astro-rerun
   src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-markdown.min.js"
 ></script>
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"
 />
-<script is:inline>
-  document.addEventListener("astro:page-load", function () {
+<script is:inline data-astro-rerun>
+  (function () {
     var body = document.querySelector(".md-editor__body");
     if (!body) return;
 
@@ -302,18 +301,23 @@ const content = rawMd.replace(/^---[\s\S]*?---\n*/, "").trim();
       }, 150);
     }
 
-    if (typeof Prism !== "undefined") {
+    // Wait for both Prism core AND markdown language component to be loaded
+    function isPrismReady() {
+      return typeof Prism !== "undefined" && Prism.languages && Prism.languages.markdown;
+    }
+
+    if (isPrismReady()) {
       runHighlight();
     } else {
       var checkInterval = setInterval(function () {
-        if (typeof Prism !== "undefined") {
+        if (isPrismReady()) {
           clearInterval(checkInterval);
           runHighlight();
         }
       }, 50);
       setTimeout(function () {
         clearInterval(checkInterval);
-      }, 3000);
+      }, 5000);
     }
-  });
+  })();
 </script>

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -155,10 +155,10 @@ await getOGImage({
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
+
     var article = document.getElementById("article");
     if (!article) return;
-
-    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
 
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -154,22 +154,26 @@ await getOGImage({
 </MainLayout>
 
 <script is:inline>
-  (function() {
+  document.addEventListener("astro:page-load", function () {
     var article = document.getElementById("article");
     if (!article) return;
 
-    // Create progress bar at body level (above nav z-index stacking context)
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
+
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();
 
     var container = document.createElement("div");
     container.id = "readingProgress";
-    container.style.cssText = "position:fixed;top:0;left:0;right:0;height:2px;z-index:9999;pointer-events:none;";
+    container.style.cssText =
+      "position:fixed;top:0;left:0;right:0;height:2px;z-index:9999;pointer-events:none;";
     var bar = document.createElement("div");
-    bar.style.cssText = "height:100%;width:0;background:var(--primary);transition:none;";
+    bar.style.cssText =
+      "height:100%;width:0;background:var(--primary);transition:none;";
     container.appendChild(bar);
     document.body.appendChild(container);
 
+    var animId;
     function update() {
       var rect = article.getBoundingClientRect();
       var total = rect.height - window.innerHeight;
@@ -179,8 +183,14 @@ await getOGImage({
       }
       var pct = Math.max(0, Math.min(100, (-rect.top / total) * 100));
       bar.style.width = pct + "%";
-      requestAnimationFrame(update);
+      animId = requestAnimationFrame(update);
     }
-    requestAnimationFrame(update);
-  })();
+    animId = requestAnimationFrame(update);
+
+    window.__readingProgressCleanup = function () {
+      cancelAnimationFrame(animId);
+      var el = document.getElementById("readingProgress");
+      if (el) el.remove();
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -157,7 +157,7 @@ const items = projects.data.items;
   </div>
 </MainLayout>
 
-<script is:inline data-astro-rerun>
+<script is:inline>
   function initFactory() {
     const factoryEl = document.getElementById("factoryWrapper");
     if (!factoryEl) return;

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -157,7 +157,7 @@ const items = projects.data.items;
   </div>
 </MainLayout>
 
-<script is:inline>
+<script is:inline data-astro-rerun>
   function initFactory() {
     const factoryEl = document.getElementById("factoryWrapper");
     if (!factoryEl) return;

--- a/daniakash.com/src/pages/resume.astro
+++ b/daniakash.com/src/pages/resume.astro
@@ -116,30 +116,43 @@ const { tagline, about, skills, jobs, community, education } = resumeData;
 </MainLayout>
 
 <script is:inline>
-  (function() {
+  document.addEventListener("astro:page-load", function () {
     var article = document.getElementById("article");
     if (!article) return;
+
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
 
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();
 
     var container = document.createElement("div");
     container.id = "readingProgress";
-    container.style.cssText = "position:fixed;top:0;left:0;right:0;height:2px;z-index:9999;pointer-events:none;";
+    container.style.cssText =
+      "position:fixed;top:0;left:0;right:0;height:2px;z-index:9999;pointer-events:none;";
     var bar = document.createElement("div");
-    bar.style.cssText = "height:100%;width:0;background:var(--primary);transition:none;";
+    bar.style.cssText =
+      "height:100%;width:0;background:var(--primary);transition:none;";
     container.appendChild(bar);
     document.body.appendChild(container);
 
+    var animId;
     function update() {
-      if (!article) return;
       var rect = article.getBoundingClientRect();
       var total = rect.height - window.innerHeight;
-      if (total <= 0) { bar.style.width = "100%"; return; }
+      if (total <= 0) {
+        bar.style.width = "100%";
+        return;
+      }
       var pct = Math.max(0, Math.min(100, (-rect.top / total) * 100));
       bar.style.width = pct + "%";
-      requestAnimationFrame(update);
+      animId = requestAnimationFrame(update);
     }
-    requestAnimationFrame(update);
-  })();
+    animId = requestAnimationFrame(update);
+
+    window.__readingProgressCleanup = function () {
+      cancelAnimationFrame(animId);
+      var el = document.getElementById("readingProgress");
+      if (el) el.remove();
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/resume.astro
+++ b/daniakash.com/src/pages/resume.astro
@@ -117,10 +117,10 @@ const { tagline, about, skills, jobs, community, education } = resumeData;
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {
+    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
+
     var article = document.getElementById("article");
     if (!article) return;
-
-    if (window.__readingProgressCleanup) window.__readingProgressCleanup();
 
     var existing = document.getElementById("readingProgress");
     if (existing) existing.remove();

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -202,11 +202,13 @@ const events = (await getCollection("speaking")).sort(
 </style>
 
 <script is:inline>
-  (function () {
+  document.addEventListener("astro:page-load", function () {
     var comp = document.getElementById("timelineComponent");
     var bar = document.getElementById("progressBar");
     var track = document.getElementById("progressTrack");
     if (!comp || !bar || !track) return;
+
+    if (window.__timelineCleanup) window.__timelineCleanup();
 
     function alignProgress() {
       var circle = comp.querySelector(".sticky.rounded-full");
@@ -219,16 +221,26 @@ const events = (await getCollection("speaking")).sort(
       }
     }
     alignProgress();
-    window.addEventListener("resize", alignProgress);
 
+    var resizeHandler = function () {
+      alignProgress();
+    };
+    window.addEventListener("resize", resizeHandler);
+
+    var animId;
     function updateProgress() {
       var rect = comp.getBoundingClientRect();
       var viewportMid = window.innerHeight * 0.5;
       var fillPx = viewportMid - rect.top;
       bar.style.height =
         Math.max(0, Math.min(fillPx, rect.height)) + "px";
-      requestAnimationFrame(updateProgress);
+      animId = requestAnimationFrame(updateProgress);
     }
-    requestAnimationFrame(updateProgress);
-  })();
+    animId = requestAnimationFrame(updateProgress);
+
+    window.__timelineCleanup = function () {
+      cancelAnimationFrame(animId);
+      window.removeEventListener("resize", resizeHandler);
+    };
+  });
 </script>

--- a/daniakash.com/src/pages/speaking.astro
+++ b/daniakash.com/src/pages/speaking.astro
@@ -203,12 +203,12 @@ const events = (await getCollection("speaking")).sort(
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {
+    if (window.__timelineCleanup) window.__timelineCleanup();
+
     var comp = document.getElementById("timelineComponent");
     var bar = document.getElementById("progressBar");
     var track = document.getElementById("progressTrack");
     if (!comp || !bar || !track) return;
-
-    if (window.__timelineCleanup) window.__timelineCleanup();
 
     function alignProgress() {
       var circle = comp.querySelector(".sticky.rounded-full");


### PR DESCRIPTION
## Problem
7 of 8 page scripts broke on View Transition (ClientRouter) navigation. Features stopped working on return visits, orphaned rAF loops accumulated consuming CPU, and resize listeners stacked on every navigation.

## Root Cause
Scripts used bare IIFEs in `<script is:inline>` that only execute on first page load. Astro's ClientRouter performs DOM swaps without full page reloads, so these scripts never re-ran.

Even the scripts that appeared to use `astro:after-swap` had deeper bugs:
- `requestAnimationFrame` loops **never cancelled** — zombie loops accumulate
- `window.addEventListener("resize", ...)` **never removed** — listeners stack
- Blog timeline used **bundled `<script>`** (runs once by design) instead of `is:inline`
- Now editor had a **guard clause** (`if table exists, return`) that prevented re-initialization

## Fix
Standard pattern applied to all scripts:

```js
document.addEventListener("astro:page-load", function () {
  if (!el) return;                              // bail if not on this page
  if (window.__cleanup) window.__cleanup();     // clean up previous
  var animId = requestAnimationFrame(loop);     // start feature
  window.__cleanup = function () {              // store cleanup for next nav
    cancelAnimationFrame(animId);
    window.removeEventListener("resize", handler);
  };
});
```

## Changes (7 files)

| Page | Fix |
|------|-----|
| Blog posts | Progress bar: astro:page-load + cancelAnimationFrame cleanup |
| Resume | Progress bar: astro:page-load + cancelAnimationFrame cleanup |
| Newsletter issues | Progress bar: astro:page-load + cancelAnimationFrame cleanup |
| Blog listing | Timeline: astro:page-load + rAF cleanup + removeEventListener (was bundled script) |
| Speaking | Timeline: astro:page-load + rAF cleanup + removeEventListener |
| Now | Editor: remove guard clause, clean up existing table before re-init |
| Projects | Factory: add data-astro-rerun (existing clearInterval cleanup sufficient) |

## Test plan
- [ ] Navigate Home → Blog post → Different blog post → progress bar resets correctly each time
- [ ] Navigate Blog post → Resume → progress bar works on resume
- [ ] Navigate Home → Blog listing → scroll → timeline animates → navigate away → return → timeline still works
- [ ] Navigate Home → Speaking → scroll → timeline works → navigate away → return → still works
- [ ] Navigate Home → Newsletter issue → Different issue → progress bar resets
- [ ] Navigate Home → Projects → Home → Projects → factory animation runs on return
- [ ] Navigate Home → Now → Home → Now → editor re-renders with syntax highlighting
- [ ] Open browser console → navigate 10+ times → no JS errors, no performance degradation