### PR TITLE
feat: about page — prose styles, progress line, clickable polaroid

### DIFF
--- a/daniakash.com/src/components/Globe.tsx
+++ b/daniakash.com/src/components/Globe.tsx
@@ -166,26 +166,25 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
     });
   }, [updateDestination]);
 
-  const [progress, setProgress] = useState(0);
-  const progressRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const progressBarRef = useRef<HTMLDivElement>(null);
+  const progressTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const startProgress = useCallback(() => {
-    if (progressRef.current) clearInterval(progressRef.current);
-    setProgress(0);
-    const interval = 100; // update every 100ms
-    const duration = 30000; // 30 seconds total
+    if (progressTimerRef.current) clearInterval(progressTimerRef.current);
+    let pct = 0;
+    if (progressBarRef.current) progressBarRef.current.style.width = "0%";
+    const interval = 100;
+    const duration = 30000;
     const step = (interval / duration) * 100;
-    progressRef.current = setInterval(() => {
-      setProgress((prev) => {
-        if (prev >= 100) return 100;
-        return prev + step;
-      });
+    progressTimerRef.current = setInterval(() => {
+      pct = Math.min(pct + step, 100);
+      if (progressBarRef.current) progressBarRef.current.style.width = pct + "%";
     }, interval);
   }, []);
 
   const resetTimer = useCallback(() => {
     if (cycleRef.current) clearInterval(cycleRef.current);
-    if (progressRef.current) clearInterval(progressRef.current);
+    if (progressTimerRef.current) clearInterval(progressTimerRef.current);
     cycleRef.current = setInterval(() => {
       next();
       startProgress();
@@ -329,7 +328,7 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
       if (globeRef.current) globeRef.current.destroy();
       if (animRef.current) cancelAnimationFrame(animRef.current);
       if (cycleRef.current) clearInterval(cycleRef.current);
-      if (progressRef.current) clearInterval(progressRef.current);
+      if (progressTimerRef.current) clearInterval(progressTimerRef.current);
       observer.disconnect();
       window.removeEventListener("resize", handleResize);
     };
@@ -396,8 +395,9 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
       {/* Progress line */}
       <div className="relative h-[2px] bg-foreground/10">
         <div
+          ref={progressBarRef}
           className="absolute inset-y-0 left-0 bg-primary transition-[width] duration-100 ease-linear"
-          style={{ width: `${progress}%` }}
+          style={{ width: "0%" }}
         />
       </div>
 

--- a/daniakash.com/src/components/Globe.tsx
+++ b/daniakash.com/src/components/Globe.tsx
@@ -186,7 +186,10 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
   const resetTimer = useCallback(() => {
     if (cycleRef.current) clearInterval(cycleRef.current);
     if (progressRef.current) clearInterval(progressRef.current);
-    cycleRef.current = setInterval(next, 30000);
+    cycleRef.current = setInterval(() => {
+      next();
+      startProgress();
+    }, 30000);
     startProgress();
   }, [next, startProgress]);
 
@@ -262,7 +265,10 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
     animate();
 
     // Auto-cycle
-    cycleRef.current = setInterval(next, 30000);
+    cycleRef.current = setInterval(() => {
+      next();
+      startProgress();
+    }, 30000);
     startProgress();
 
     // Theme observer

--- a/daniakash.com/src/components/Globe.tsx
+++ b/daniakash.com/src/components/Globe.tsx
@@ -106,7 +106,7 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
-  const polaroidRef = useRef<HTMLDivElement>(null);
+  const polaroidRef = useRef<HTMLAnchorElement>(null);
   const [startIdx] = useState(() =>
     Math.floor(Math.random() * DESTINATIONS.length),
   );
@@ -166,10 +166,29 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
     });
   }, [updateDestination]);
 
+  const [progress, setProgress] = useState(0);
+  const progressRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startProgress = useCallback(() => {
+    if (progressRef.current) clearInterval(progressRef.current);
+    setProgress(0);
+    const interval = 100; // update every 100ms
+    const duration = 30000; // 30 seconds total
+    const step = (interval / duration) * 100;
+    progressRef.current = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) return 100;
+        return prev + step;
+      });
+    }, interval);
+  }, []);
+
   const resetTimer = useCallback(() => {
     if (cycleRef.current) clearInterval(cycleRef.current);
+    if (progressRef.current) clearInterval(progressRef.current);
     cycleRef.current = setInterval(next, 30000);
-  }, [next]);
+    startProgress();
+  }, [next, startProgress]);
 
   // Create globe
   useEffect(() => {
@@ -244,6 +263,7 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
 
     // Auto-cycle
     cycleRef.current = setInterval(next, 30000);
+    startProgress();
 
     // Theme observer
     const observer = new MutationObserver(() => {
@@ -303,6 +323,7 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
       if (globeRef.current) globeRef.current.destroy();
       if (animRef.current) cancelAnimationFrame(animRef.current);
       if (cycleRef.current) clearInterval(cycleRef.current);
+      if (progressRef.current) clearInterval(progressRef.current);
       observer.disconnect();
       window.removeEventListener("resize", handleResize);
     };
@@ -346,20 +367,32 @@ export default function Globe({ destinations: destinationsProp }: GlobeProps) {
             }
           }}
         />
-        {/* Polaroid card — anchored to marker */}
-        <div
+        {/* Polaroid card — anchored to marker, clickable */}
+        <a
           ref={polaroidRef}
+          href={d.w}
+          target="_blank"
+          rel="noopener"
           className="polaroid"
           style={{
             transition: "opacity 0.6s, filter 0.6s, left 0.3s, top 0.3s",
+            pointerEvents: "auto",
           }}
         >
           <img src={d.img} alt={d.n} className="polaroid-img" />
           <div className="polaroid-caption">{d.n}</div>
-        </div>
+        </a>
         <span className="absolute bottom-2 right-4 pointer-events-none font-mono text-[9px] uppercase tracking-wider text-muted-foreground/60">
           DESTINATIONS // WISHLIST
         </span>
+      </div>
+
+      {/* Progress line */}
+      <div className="relative h-[2px] bg-foreground/10">
+        <div
+          className="absolute inset-y-0 left-0 bg-primary transition-[width] duration-100 ease-linear"
+          style={{ width: `${progress}%` }}
+        />
       </div>
 
       {/* Spotlight panel */}

--- a/daniakash.com/src/content/about/about.mdx
+++ b/daniakash.com/src/content/about/about.mdx
@@ -2,6 +2,6 @@ It all started with [3D Pinball](https://www.youtube.com/watch?v=uMZwb05pPnI) on
 
 These days, I’m an enthusiastic **worldbuilder** in every sense. I love learning about the big stuff that makes our world tick – from **global economics** 🌍 to **particle physics** 🧬. My classroom? Books, documentaries, and the endless stream of educational YouTube rabbit holes. I’m equally into imaginary worlds too, so you’ll find me lost in [anime](https://myanimelist.net/profile/piratehunter) and [games](https://psnprofiles.com/hunter_vrtx) like _One Piece_, _Evangelion_, and _Tekken_ 🎮
 
-## SYS.STATUS // CURRENT
+## SYSTEM.STATUS // CURRENT
 
 Today, I’m a programmer, engineering manager, and an occasional educator. I specialize in building high-performance web and mobile applications using modern JavaScript frameworks, GraphQL, tRPC, serverless and edge runtimes. When I’m not coding, I’m teaching others how to kickstart their tech careers and find their own path in this ever-evolving digital world 🚀

--- a/daniakash.com/src/layouts/MainLayout.astro
+++ b/daniakash.com/src/layouts/MainLayout.astro
@@ -77,7 +77,7 @@ if (pathSegments.length > 0) {
 const isHomePage = Astro.url.pathname === "/";
 ---
 
-<html lang="en" class="dark">
+<html lang="en" class="dark overflow-x-clip">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -181,7 +181,7 @@ const isHomePage = Astro.url.pathname === "/";
       document.addEventListener("astro:after-swap", restoreTheme);
     </script>
   </head>
-  <body class="min-h-screen overflow-x-clip bg-background text-foreground">
+  <body class="min-h-screen bg-background text-foreground">
     <Nav />
     <main class="relative z-1 mx-auto max-w-7xl px-6 pt-24">
       <slot />

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -141,12 +141,12 @@ const destinations = destinationsData.data.items;
   .about-subtitle {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: hsl(var(--muted-foreground));
+    color: var(--muted-foreground);
     letter-spacing: 0.15em;
     text-transform: uppercase;
     margin-bottom: 24px;
     padding-bottom: 8px;
-    border-bottom: 1px dashed hsl(var(--border));
+    border-bottom: 1px dashed var(--border);
   }
 
   /* Connect links */
@@ -159,7 +159,7 @@ const destinations = destinationsData.data.items;
   .connect-link {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 13px;
-    color: hsl(var(--muted-foreground));
+    color: var(--muted-foreground);
     display: flex;
     align-items: center;
     gap: 8px;
@@ -169,7 +169,7 @@ const destinations = destinationsData.data.items;
   }
 
   .connect-link:hover {
-    color: hsl(var(--primary));
+    color: var(--primary);
   }
 
   /* Right column — sticky globe */
@@ -226,7 +226,7 @@ const destinations = destinationsData.data.items;
     font-size: 10px;
     font-weight: 500;
     text-align: center;
-    color: hsl(var(--foreground));
+    color: var(--foreground);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -261,7 +261,7 @@ const destinations = destinationsData.data.items;
   .about-viz :global(.spotlight-btn) {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 14px;
-    color: hsl(var(--muted-foreground));
+    color: var(--muted-foreground);
     background: none;
     border: 1px solid #1e1e2a;
     border-radius: 8px;
@@ -280,15 +280,15 @@ const destinations = destinationsData.data.items;
   }
 
   .about-viz :global(.spotlight-btn:hover) {
-    color: hsl(var(--primary));
-    border-color: hsl(var(--primary));
-    background: hsl(var(--primary) / 0.15);
+    color: var(--primary);
+    border-color: var(--primary);
+    background: oklch(from var(--primary) l c h / 0.15);
   }
 
   .about-viz :global(.spotlight-input) {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: hsl(var(--foreground));
+    color: var(--foreground);
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid #1e1e2a;
     border-radius: 4px;
@@ -306,7 +306,7 @@ const destinations = destinationsData.data.items;
   }
 
   .about-viz :global(.spotlight-input:focus) {
-    border-color: hsl(var(--primary));
+    border-color: var(--primary);
   }
 
   .about-viz :global(.spotlight-input::-webkit-inner-spin-button),

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -77,7 +77,7 @@ const destinations = destinationsData.data.items;
             I'm Dani Akash
           </h1>
 
-          <div class="about-body">
+          <div class="prose dark:prose-invert max-w-none">
             <Content />
           </div>
 
@@ -131,12 +131,6 @@ const destinations = destinationsData.data.items;
   /* Left column — scrolls naturally */
   .about-content {
     padding: 80px 0;
-  }
-
-  .about-body {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
   }
 
   /* Subsection dividers */
@@ -209,7 +203,6 @@ const destinations = destinationsData.data.items;
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 8px;
     overflow: hidden;
-    pointer-events: none;
     z-index: 3;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     opacity: 0;
@@ -348,70 +341,3 @@ const destinations = destinationsData.data.items;
   }
 </style>
 
-<style is:global>
-  /* About body content styles — must be global to override Tailwind layers */
-  .about-body p {
-    color: rgba(255, 255, 255, 0.55) !important;
-    font-size: 16px !important;
-    line-height: 1.75 !important;
-  }
-  html:not(.dark) .about-body p {
-    color: rgba(0, 0, 0, 0.55) !important;
-  }
-
-  .about-body strong,
-  .about-body b {
-    color: rgba(255, 255, 255, 0.55) !important;
-  }
-  html:not(.dark) .about-body strong,
-  html:not(.dark) .about-body b {
-    color: rgba(0, 0, 0, 0.55) !important;
-  }
-
-  .about-body a {
-    color: hsl(var(--primary)) !important;
-    text-decoration: none !important;
-    border-bottom: 1px dashed hsl(var(--primary)) !important;
-  }
-  .about-body a:hover {
-    border-bottom-style: solid !important;
-  }
-
-  .about-body h2,
-  .about-body h3,
-  .about-body h4 {
-    font-family: 'JetBrains Mono', 'SF Mono', monospace !important;
-    font-size: 11px !important;
-    color: rgba(255, 255, 255, 0.3) !important;
-    letter-spacing: 0.15em !important;
-    text-transform: uppercase !important;
-    margin-top: 48px !important;
-    margin-bottom: 24px !important;
-    padding-bottom: 8px !important;
-    border-bottom: 1px dashed rgba(255, 255, 255, 0.1) !important;
-    font-weight: 400 !important;
-  }
-  html:not(.dark) .about-body h2,
-  html:not(.dark) .about-body h3,
-  html:not(.dark) .about-body h4 {
-    color: rgba(0, 0, 0, 0.35) !important;
-    border-bottom-color: rgba(0, 0, 0, 0.1) !important;
-  }
-
-  /* SYS.CONNECT subtitle (outside about-body) */
-  .about-subtitle {
-    font-family: 'JetBrains Mono', 'SF Mono', monospace !important;
-    font-size: 11px !important;
-    color: rgba(255, 255, 255, 0.3) !important;
-    letter-spacing: 0.15em !important;
-    text-transform: uppercase !important;
-    margin-bottom: 24px !important;
-    padding-bottom: 8px !important;
-    border-bottom: 1px dashed rgba(255, 255, 255, 0.1) !important;
-    font-weight: 400 !important;
-  }
-  html:not(.dark) .about-subtitle {
-    color: rgba(0, 0, 0, 0.35) !important;
-    border-bottom-color: rgba(0, 0, 0, 0.1) !important;
-  }
-</style>

--- a/daniakash.com/src/pages/about.astro
+++ b/daniakash.com/src/pages/about.astro
@@ -82,7 +82,7 @@ const destinations = destinationsData.data.items;
           </div>
 
           <div class="about-section">
-            <div class="about-subtitle">SYS.CONNECT // UPLINKS</div>
+            <div class="about-subtitle">SYSTEM.CONNECT // UPLINKS</div>
             <div class="about-connect">
               <a href={social.data.bluesky} class="connect-link" target="_blank" rel="noopener">
                 <BlueskyIcon /><span class="ml-4">Follow on Bluesky</span>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -87,7 +87,7 @@ const heroImages = [
         <p
           class="text-muted-foreground mb-6 font-mono text-[11px] tracking-[1.65px] uppercase"
         >
-          SYS.ROLE // AI_ENGINEER &middot; BUILDER &middot; SPEAKER
+          SYSTEM.ROLE // AI_ENGINEER &middot; BUILDER &middot; SPEAKER
         </p>
         <h1
           class="mb-6 leading-[1.05] font-bold tracking-[-0.03em]"

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -72,13 +72,22 @@ await getOGImage({
     }}
   />
   <article class="mx-auto max-w-[720px] pt-[120px] pb-20" id="article">
-    <!-- Back link -->
-    <a
-      href="/blog/"
-      class="mb-12 inline-flex items-center gap-2 font-mono text-xs tracking-wide text-muted-foreground transition-colors hover:text-primary"
-    >
-      ← Back to blog
-    </a>
+    <!-- Navigation -->
+    <div class="mb-12 flex items-center gap-4 font-mono text-xs tracking-wide">
+      <button
+        onclick="history.back()"
+        class="inline-flex items-center gap-2 text-muted-foreground transition-colors hover:text-primary"
+      >
+        ← Back
+      </button>
+      <span class="text-border" aria-hidden="true">|</span>
+      <a
+        href="/blog/"
+        class="text-muted-foreground transition-colors hover:text-primary"
+      >
+        All posts
+      </a>
+    </div>
 
     <!-- Post header -->
     <div class="mb-4 flex items-center gap-3 font-mono text-[13px] tracking-wide text-muted-foreground">
@@ -141,13 +150,20 @@ await getOGImage({
 
     <!-- Article footer -->
     <div
-      class="mt-12 flex items-center justify-between border-t border-dashed border-border pt-12"
+      class="mt-12 flex items-center gap-4 border-t border-dashed border-border pt-12 font-mono text-[13px]"
     >
+      <button
+        onclick="history.back()"
+        class="text-muted-foreground transition-colors hover:text-primary"
+      >
+        ← Back
+      </button>
+      <span class="text-border" aria-hidden="true">|</span>
       <a
         href="/blog/"
-        class="font-mono text-[13px] text-muted-foreground transition-colors hover:text-primary"
+        class="text-muted-foreground transition-colors hover:text-primary"
       >
-        ← All posts
+        All posts
       </a>
     </div>
   </article>

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -803,7 +803,7 @@ const items = projects.data.items;
     bottom: -150px;
     left: 50%;
     margin-left: -712px;
-    background-color: hsl(var(--background));
+    background-color: var(--background);
   }
 
   .factory-wrapper :global(*) {

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -762,7 +762,11 @@ const items = projects.data.items;
     }
   }
 
-  document.addEventListener("astro:page-load", initFactory);
+  document.addEventListener("astro:page-load", () => {
+    setTimeout(() => {
+      initFactory();
+    }, 175);
+  });
 </script>
 
 <style>

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -11,7 +11,7 @@ const items = projects.data.items;
   description="Projects by Dani Akash | from browser extensions to open source libraries to AI agents."
 >
   <!-- Factory Background — fixed, masked, behind content -->
-  <div class="factory-fixed">
+  <div class="factory-fixed" style="view-transition-name: factory;">
     <div class="factory-wrapper" id="factoryWrapper"></div>
   </div>
 
@@ -967,6 +967,12 @@ const items = projects.data.items;
 
   :global(html:not(.dark)) .factory-fixed {
     opacity: 0.6;
+  }
+
+  /* Prevent View Transition crossfade flash on the factory */
+  ::view-transition-old(factory),
+  ::view-transition-new(factory) {
+    animation: none;
   }
 
   .bento-grid {

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -793,7 +793,6 @@ const items = projects.data.items;
     left: 50%;
     margin-left: -712px;
     background-color: hsl(var(--background));
-    transition: background-color 0.4s ease;
   }
 
   .factory-wrapper :global(*) {
@@ -835,9 +834,6 @@ const items = projects.data.items;
     filter: brightness(2.5);
   }
 
-  :global(.dark) .factory-fixed :global(.pix::after) {
-    filter: brightness(2.5);
-  }
   :global(html:not(.dark)) .factory-fixed :global(.pix::after) {
     filter: brightness(0.4);
   }

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -11,7 +11,7 @@ const items = projects.data.items;
   description="Projects by Dani Akash | from browser extensions to open source libraries to AI agents."
 >
   <!-- Factory Background — fixed, masked, behind content -->
-  <div class="factory-fixed" id="factoryFixed" style="opacity: 0;">
+  <div class="factory-fixed factory-hidden" id="factoryFixed">
     <div class="factory-wrapper" id="factoryWrapper"></div>
   </div>
 
@@ -754,14 +754,11 @@ const items = projects.data.items;
     world.start();
     window.__factoryInterval = world.interval;
 
-    // Fade in factory after View Transition completes
+    // Reveal factory — hidden by CSS until astro:page-load fires
     var fixedEl = document.getElementById("factoryFixed");
     if (fixedEl) {
-      var targetOpacity = isDark() ? "1" : "0.6";
       fixedEl.style.transition = "opacity 0.5s ease";
-      requestAnimationFrame(function () {
-        fixedEl.style.opacity = targetOpacity;
-      });
+      fixedEl.classList.remove("factory-hidden");
     }
   }
 
@@ -975,7 +972,14 @@ const items = projects.data.items;
     }
   }
 
-  /* Light mode opacity is set by JS in initFactory to avoid VT flash */
+  :global(html:not(.dark)) .factory-fixed {
+    opacity: 0.6;
+  }
+
+  /* Factory starts hidden — revealed by initFactory after astro:page-load */
+  .factory-hidden {
+    opacity: 0 !important;
+  }
 
   .bento-grid {
     display: grid;

--- a/daniakash.com/src/pages/projects.astro
+++ b/daniakash.com/src/pages/projects.astro
@@ -11,7 +11,7 @@ const items = projects.data.items;
   description="Projects by Dani Akash | from browser extensions to open source libraries to AI agents."
 >
   <!-- Factory Background — fixed, masked, behind content -->
-  <div class="factory-fixed" style="view-transition-name: factory;">
+  <div class="factory-fixed" id="factoryFixed" style="opacity: 0;">
     <div class="factory-wrapper" id="factoryWrapper"></div>
   </div>
 
@@ -753,6 +753,16 @@ const items = projects.data.items;
     world.renderFromConfigs(themedConfig);
     world.start();
     window.__factoryInterval = world.interval;
+
+    // Fade in factory after View Transition completes
+    var fixedEl = document.getElementById("factoryFixed");
+    if (fixedEl) {
+      var targetOpacity = isDark() ? "1" : "0.6";
+      fixedEl.style.transition = "opacity 0.5s ease";
+      requestAnimationFrame(function () {
+        fixedEl.style.opacity = targetOpacity;
+      });
+    }
   }
 
   document.addEventListener("astro:page-load", initFactory);
@@ -965,15 +975,7 @@ const items = projects.data.items;
     }
   }
 
-  :global(html:not(.dark)) .factory-fixed {
-    opacity: 0.6;
-  }
-
-  /* Prevent View Transition crossfade flash on the factory */
-  ::view-transition-old(factory),
-  ::view-transition-new(factory) {
-    animation: none;
-  }
+  /* Light mode opacity is set by JS in initFactory to avoid VT flash */
 
   .bento-grid {
     display: grid;


### PR DESCRIPTION
## Summary

### About page
- **Replace custom CSS with prose class** — swapped `about-body` with `prose dark:prose-invert`, removed ~65 lines of `!important` overrides
- **Progress line above spotlight** — animated bar shows countdown to next destination auto-switch (30s cycle), resets on manual navigation. Uses ref-based DOM updates instead of React state to avoid re-renders.
- **Clickable polaroid card** — opens Wikipedia link in new tab (`<div>` → `<a>`)
- **Fix invalid `hsl(var())` CSS** — design tokens are oklch, not HSL channels. Fixed all occurrences so hover highlights work correctly on connect links.

### Homepage
- **Rename SYS. → SYSTEM.** across all pages (homepage hero, about headings, about connect section)

### Projects page
- **Fix factory bright flash on View Transition** — factory starts hidden (`factory-hidden` class), revealed after `astro:page-load` fires
- **Fix invalid `hsl(var(--background))`** in factory wrapper CSS

## Test plan
- [ ] About page prose content renders correctly (text color, links, headings)
- [ ] Connect links highlight on hover (teal color)
- [ ] Progress line animates 0→100% over 30s, resets on prev/next
- [ ] Clicking polaroid opens Wikipedia in new tab
- [ ] Globe drag still works
- [ ] Factory doesn't flash bright during View Transition to projects page
- [ ] Light/dark mode both render correctly on all affected pages