### PR TITLE
fix(nav): add mobile hamburger menu

### DIFF
--- a/daniakash.com/src/components/Nav.astro
+++ b/daniakash.com/src/components/Nav.astro
@@ -57,7 +57,7 @@ const currentPath = Astro.url.pathname;
 
   <div
     id="mobile-menu"
-    class="border-border bg-background/95 hidden border-t backdrop-blur-xl md:hidden"
+    class="border-border bg-background/70 hidden border-t backdrop-blur-xl md:hidden"
   >
     <ul class="mx-auto max-w-7xl px-6 py-4 flex flex-col gap-1">
       {

--- a/daniakash.com/src/components/Nav.astro
+++ b/daniakash.com/src/components/Nav.astro
@@ -39,6 +39,84 @@ const currentPath = Astro.url.pathname;
       }
     </ul>
 
-    <ThemeToggle client:idle />
+    <div class="flex items-center gap-3">
+      <ThemeToggle client:idle />
+
+      <button
+        id="mobile-menu-toggle"
+        class="text-muted-foreground hover:text-foreground flex h-8 w-8 items-center justify-center font-mono text-lg transition-colors md:hidden"
+        aria-label="Toggle navigation menu"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+      >
+        <span id="hamburger-icon" aria-hidden="true">≡</span>
+        <span id="close-icon" aria-hidden="true" class="hidden">✕</span>
+      </button>
+    </div>
+  </div>
+
+  <div
+    id="mobile-menu"
+    class="border-border bg-background/95 hidden border-t backdrop-blur-xl md:hidden"
+  >
+    <ul class="mx-auto max-w-7xl px-6 py-4 flex flex-col gap-1">
+      {
+        navLinks.map((link) => {
+          const isActive = currentPath.startsWith(link.href);
+          return (
+            <li>
+              <a
+                href={link.href}
+                class:list={[
+                  "mobile-nav-link block rounded-md px-4 py-2 font-mono text-[11px] uppercase tracking-[0.15em] transition-all",
+                  isActive
+                    ? "text-primary"
+                    : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+                ]}
+              >
+                {link.title}
+              </a>
+            </li>
+          );
+        })
+      }
+    </ul>
   </div>
 </nav>
+
+<script>
+  const toggle = document.getElementById("mobile-menu-toggle");
+  const menu = document.getElementById("mobile-menu");
+  const hamburgerIcon = document.getElementById("hamburger-icon");
+  const closeIcon = document.getElementById("close-icon");
+
+  function openMenu() {
+    menu?.classList.remove("hidden");
+    hamburgerIcon?.classList.add("hidden");
+    closeIcon?.classList.remove("hidden");
+    toggle?.setAttribute("aria-expanded", "true");
+  }
+
+  function closeMenu() {
+    menu?.classList.add("hidden");
+    hamburgerIcon?.classList.remove("hidden");
+    closeIcon?.classList.add("hidden");
+    toggle?.setAttribute("aria-expanded", "false");
+  }
+
+  toggle?.addEventListener("click", () => {
+    const isOpen = toggle.getAttribute("aria-expanded") === "true";
+    if (isOpen) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  const mobileLinks = document.querySelectorAll(".mobile-nav-link");
+  mobileLinks.forEach((link) => {
+    link.addEventListener("click", () => {
+      closeMenu();
+    });
+  });
+</script>


### PR DESCRIPTION
## Problem

On mobile viewports (below 768px), all navigation links were hidden with no way for users to access them. The nav bar only showed the site logo and theme toggle, leaving mobile visitors unable to navigate.

## Solution

Added a responsive hamburger menu that activates on mobile (below the `md:` breakpoint):

- **Hamburger button** — minimal `≡` / `✕` text characters, styled with existing `font-mono` design tokens, sits next to the ThemeToggle on mobile
- **Mobile drawer** — slides in below the nav bar, lists all nav links (`About`, `Blog`, `Newsletter`, `Projects`, `Speaking`, `Uses`, `Now`) in the same `font-mono text-[11px] uppercase tracking-[0.15em]` style as desktop
- **Active state** — current page link highlighted with `text-primary`, matching desktop behaviour
- **Auto-close** — menu closes when a nav link is tapped
- **Accessibility** — button uses `aria-expanded` and `aria-controls`, icon spans are `aria-hidden`
- **Backdrop blur** — mobile menu uses `bg-background/95 backdrop-blur-xl` to match the nav bar aesthetic

## Files changed

- `daniakash.com/src/components/Nav.astro` — added hamburger button, mobile menu drawer, and inline toggle script