### PR TITLE
fix(home): resolve mobile overflow and blog grid layout issues

### DIFF
--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -155,7 +155,7 @@ const heroImages = [
 
     <!-- Photo gallery — full viewport width, bleeding off bottom -->
     <div
-      class="pointer-events-none absolute bottom-0 left-1/2 z-1 h-[380px] w-screen -translate-x-1/2 overflow-y-clip"
+      class="pointer-events-none absolute bottom-0 left-1/2 z-1 h-[380px] w-screen -translate-x-1/2 overflow-clip"
     >
       <div
         class="pointer-events-auto absolute bottom-[-120px] left-1/2 flex -translate-x-1/2 items-start gap-4"
@@ -223,7 +223,7 @@ const heroImages = [
               return (
                 <a
                   href={`/posts/${post.id}/`}
-                  class="group border-border hover:bg-foreground/5 -mx-4 grid grid-cols-[140px_1fr_auto] items-baseline gap-6 border-b border-dashed px-4 py-4 transition-colors last:border-b-0 hover:rounded-sm"
+                  class="group border-border hover:bg-foreground/5 -mx-4 grid grid-cols-[90px_1fr] items-baseline gap-4 border-b border-dashed px-4 py-4 transition-colors last:border-b-0 hover:rounded-sm sm:grid-cols-[140px_1fr_auto] sm:gap-6"
                 >
                   <span class="text-muted-foreground font-mono text-xs">
                     {formatted}
@@ -231,7 +231,7 @@ const heroImages = [
                   <span class="group-hover:text-primary text-base font-medium transition-colors">
                     {post.data.title}
                   </span>
-                  <span class="text-muted-foreground font-mono text-sm transition-transform group-hover:translate-x-1">
+                  <span class="text-muted-foreground hidden font-mono text-sm transition-transform group-hover:translate-x-1 sm:inline">
                     →
                   </span>
                 </a>
@@ -361,7 +361,7 @@ const heroImages = [
         method="post"
         target="popupwindow"
         onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[480px] gap-2"
+        class="mx-auto flex max-w-[480px] flex-col gap-2 sm:flex-row"
       >
         <input
           type="email"
@@ -369,7 +369,7 @@ const heroImages = [
           placeholder="user@domain.net"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
         />
         <button
           type="submit"

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -351,7 +351,7 @@ const heroImages = [
 
   <!-- ═══ NEWSLETTER ═══ -->
   <section class="py-20">
-    <div class="border-border bg-card rounded-2xl border p-12 text-center">
+    <div class="border-border bg-card rounded-2xl border p-6 text-center sm:p-12">
       <h2 class="mb-2 text-[28px] font-semibold">Stay in the loop</h2>
       <p class="text-muted-foreground mb-6">
         Thoughts delivered straight to your inbox. Zero spam, I promise.
@@ -373,7 +373,7 @@ const heroImages = [
         />
         <button
           type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-12 rounded-full px-6 font-mono text-sm font-medium transition-colors"
+          class="bg-primary text-primary-foreground hover:bg-primary/80 h-12 w-full rounded-full px-6 font-mono text-sm font-medium transition-colors sm:w-auto"
         >
           SUBSCRIBE
         </button>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -351,7 +351,7 @@ const heroImages = [
 
   <!-- ═══ NEWSLETTER ═══ -->
   <section class="py-20">
-    <div class="border-border bg-card rounded-2xl border p-6 text-center sm:p-12">
+    <div class="border-border bg-card rounded-2xl border p-12 text-center">
       <h2 class="mb-2 text-[28px] font-semibold">Stay in the loop</h2>
       <p class="text-muted-foreground mb-6">
         Thoughts delivered straight to your inbox. Zero spam, I promise.
@@ -369,7 +369,7 @@ const heroImages = [
           placeholder="user@domain.net"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
         />
         <button
           type="submit"

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -8,6 +8,7 @@ import LinkedinIcon from "../components/icons/LinkedinIcon.astro";
 import MailIcon from "../components/icons/MailIcon.astro";
 import TwitterIcon from "../components/icons/TwitterIcon.astro";
 import { assetUrl } from "../constants/asset-prefix";
+import Newsletter from "../components/Newsletter.astro";
 import MainLayout from "../layouts/MainLayout.astro";
 
 const posts = (await getCollection("blog"))
@@ -351,33 +352,11 @@ const heroImages = [
 
   <!-- ═══ NEWSLETTER ═══ -->
   <section class="py-20">
-    <div class="border-border bg-card rounded-2xl border p-12 text-center">
-      <h2 class="mb-2 text-[28px] font-semibold">Stay in the loop</h2>
-      <p class="text-muted-foreground mb-6">
-        Thoughts delivered straight to your inbox. Zero spam, I promise.
-      </p>
-      <form
-        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[480px] flex-col gap-2 sm:flex-row"
-      >
-        <input
-          type="email"
-          name="email"
-          placeholder="user@domain.net"
-          required
-          aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
-        />
-        <button
-          type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-12 w-full rounded-full px-6 font-mono text-sm font-medium transition-colors sm:w-auto"
-        >
-          SUBSCRIBE
-        </button>
-      </form>
-    </div>
+    <Newsletter
+      heading="Stay in the loop"
+      description="Thoughts delivered straight to your inbox. Zero spam, I promise."
+      buttonLabel="SUBSCRIBE"
+      class="bg-card p-12"
+    />
   </section>
 </MainLayout>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -8,7 +8,6 @@ import LinkedinIcon from "../components/icons/LinkedinIcon.astro";
 import MailIcon from "../components/icons/MailIcon.astro";
 import TwitterIcon from "../components/icons/TwitterIcon.astro";
 import { assetUrl } from "../constants/asset-prefix";
-import Newsletter from "../components/Newsletter.astro";
 import MainLayout from "../layouts/MainLayout.astro";
 
 const posts = (await getCollection("blog"))
@@ -352,11 +351,33 @@ const heroImages = [
 
   <!-- ═══ NEWSLETTER ═══ -->
   <section class="py-20">
-    <Newsletter
-      heading="Stay in the loop"
-      description="Thoughts delivered straight to your inbox. Zero spam, I promise."
-      buttonLabel="SUBSCRIBE"
-      class="bg-card p-12"
-    />
+    <div class="border-border bg-card rounded-2xl border p-12 text-center">
+      <h2 class="mb-2 text-[28px] font-semibold">Stay in the loop</h2>
+      <p class="text-muted-foreground mb-6">
+        Thoughts delivered straight to your inbox. Zero spam, I promise.
+      </p>
+      <form
+        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
+        method="post"
+        target="popupwindow"
+        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
+        class="mx-auto flex max-w-[480px] flex-col gap-2 sm:flex-row"
+      >
+        <input
+          type="email"
+          name="email"
+          placeholder="user@domain.net"
+          required
+          aria-label="Email address"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
+        />
+        <button
+          type="submit"
+          class="bg-primary text-primary-foreground hover:bg-primary/80 h-12 w-full rounded-full px-6 font-mono text-sm font-medium transition-colors sm:w-auto"
+        >
+          SUBSCRIBE
+        </button>
+      </form>
+    </div>
   </section>
 </MainLayout>


### PR DESCRIPTION
## What this fixes

### Issue 1 — Hero photo strip horizontal scroll
The photo strip wrapper used `overflow-y-clip` which only clips the y-axis, leaving x-axis unconstrained. At viewport widths around 768–1280px this caused a horizontal scrollbar to appear.

**Fix:** Changed `overflow-y-clip` → `overflow-clip` on the strip container so both axes are clipped.

### Issue 2 — Blog post list overflow on mobile
The blog post grid used a fixed 3-column layout (`grid-cols-[140px_1fr_auto]`) at all widths. On small screens (≤375px) the 140px date column caused the row to overflow the viewport.

**Fix:** Collapsed to a 2-column layout on mobile (`grid-cols-[90px_1fr]`) and hid the arrow glyph (`hidden sm:inline`), restoring the 3-column layout with the full 140px date column at `sm` and above.