### PR TITLE
fix(post): stack subscribe form on mobile

### DIFF
--- a/daniakash.com/src/components/Newsletter.astro
+++ b/daniakash.com/src/components/Newsletter.astro
@@ -30,7 +30,7 @@ const {
 >
   {
     label && (
-      <div class="text-muted-foreground mb-2 font-mono text-[11px] uppercase tracking-[0.1em]">
+      <div class="text-muted-foreground mb-2 font-mono text-[11px] tracking-[0.1em] uppercase">
         {label}
       </div>
     )
@@ -53,7 +53,7 @@ const {
       placeholder="you@email.com"
       required
       aria-label="Email address"
-      class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
+      class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-4 py-2 font-mono text-sm transition-colors outline-none sm:px-6"
     />
     <button
       type="submit"

--- a/daniakash.com/src/components/Newsletter.astro
+++ b/daniakash.com/src/components/Newsletter.astro
@@ -1,36 +1,65 @@
 ---
-import { TRANSITION_NAMES } from "../constants/transition-names";
-import MailIcon from "./icons/MailIcon.astro";
+interface Props {
+  heading: string;
+  description: string;
+  /** Optional mono-text label rendered above the heading */
+  label?: string;
+  /** Button text, defaults to "Subscribe" */
+  buttonLabel?: string;
+  /** Center-align heading, description, and form. Defaults to true */
+  center?: boolean;
+  class?: string;
+}
+
+const {
+  heading,
+  description,
+  label,
+  buttonLabel = "Subscribe",
+  center = true,
+  class: className,
+} = Astro.props;
 ---
 
-<form
-  action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-  method="post"
-  target="popupwindow"
-  onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-  class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40"
-  transition:name={TRANSITION_NAMES.newsletterForm}
+<div
+  class:list={[
+    "border-border bg-foreground/[0.025] rounded-2xl border p-8",
+    center && "text-center",
+    className,
+  ]}
 >
-  <h2 class="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-    <MailIcon class="h-6 w-6 flex-none" />
-    <span class="ml-3">Stay up to date</span>
-  </h2>
-  <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-    Get notified when I publish something new, and unsubscribe at any time.
-  </p>
-  <div class="mt-6 flex">
+  {
+    label && (
+      <div class="text-muted-foreground mb-2 font-mono text-[11px] uppercase tracking-[0.1em]">
+        {label}
+      </div>
+    )
+  }
+  <h2 class="mb-2 text-xl font-semibold">{heading}</h2>
+  <p class="text-muted-foreground mb-6 text-sm">{description}</p>
+  <form
+    action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
+    method="post"
+    target="popupwindow"
+    onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
+    class:list={[
+      "flex max-w-[480px] flex-col gap-2 sm:flex-row",
+      center && "mx-auto",
+    ]}
+  >
     <input
       type="email"
       name="email"
-      id="bd-email"
-      placeholder="Email address"
-      aria-label="Email address"
+      placeholder="you@email.com"
       required
-      class="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(theme(spacing.2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-500/10 dark:border-zinc-700 dark:bg-zinc-700/[0.15] dark:text-zinc-200 dark:placeholder:text-zinc-500 dark:focus:border-teal-400 dark:focus:ring-teal-400/10 sm:text-sm"
+      aria-label="Email address"
+      class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
     />
     <button
-      class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md bg-zinc-800 px-3 py-2 text-sm font-semibold text-zinc-100 outline-offset-2 transition hover:bg-zinc-700 active:bg-zinc-800 active:text-zinc-100/70 active:transition-none dark:bg-zinc-700 dark:hover:bg-zinc-600 dark:active:bg-zinc-700 dark:active:text-zinc-100/70"
-      type="submit">Join</button
+      type="submit"
+      class="bg-primary text-primary-foreground hover:bg-primary/80 h-11 w-full rounded-full px-6 font-mono text-[13px] font-medium transition-colors sm:w-auto"
     >
-  </div>
-</form>
+      {buttonLabel}
+    </button>
+  </form>
+</div>

--- a/daniakash.com/src/pages/index.astro
+++ b/daniakash.com/src/pages/index.astro
@@ -8,6 +8,7 @@ import LinkedinIcon from "../components/icons/LinkedinIcon.astro";
 import MailIcon from "../components/icons/MailIcon.astro";
 import TwitterIcon from "../components/icons/TwitterIcon.astro";
 import { assetUrl } from "../constants/asset-prefix";
+import Newsletter from "../components/Newsletter.astro";
 import MainLayout from "../layouts/MainLayout.astro";
 
 const posts = (await getCollection("blog"))
@@ -56,11 +57,26 @@ const connectLinks = [
 ];
 
 const heroImages = [
-  { src: assetUrl("image-1.jpg"), alt: "Dani Akash posing with a cosplayer in a fighting stance" },
-  { src: assetUrl("image-2.jpg"), alt: "Dani Akash coding at his desk with a cat on his lap" },
-  { src: assetUrl("image-3.jpg"), alt: "Dani Akash speaking at a tech meetup with a microphone" },
-  { src: assetUrl("image-4.jpg"), alt: "Dani Akash overlooking a river gorge on a hike" },
-  { src: assetUrl("image-5.jpg"), alt: "Dani Akash examining a large decorative sculpture at a market" },
+  {
+    src: assetUrl("image-1.jpg"),
+    alt: "Dani Akash posing with a cosplayer in a fighting stance",
+  },
+  {
+    src: assetUrl("image-2.jpg"),
+    alt: "Dani Akash coding at his desk with a cat on his lap",
+  },
+  {
+    src: assetUrl("image-3.jpg"),
+    alt: "Dani Akash speaking at a tech meetup with a microphone",
+  },
+  {
+    src: assetUrl("image-4.jpg"),
+    alt: "Dani Akash overlooking a river gorge on a hike",
+  },
+  {
+    src: assetUrl("image-5.jpg"),
+    alt: "Dani Akash examining a large decorative sculpture at a market",
+  },
 ];
 ---
 
@@ -351,33 +367,11 @@ const heroImages = [
 
   <!-- ═══ NEWSLETTER ═══ -->
   <section class="py-20">
-    <div class="border-border bg-card rounded-2xl border p-12 text-center">
-      <h2 class="mb-2 text-[28px] font-semibold">Stay in the loop</h2>
-      <p class="text-muted-foreground mb-6">
-        Thoughts delivered straight to your inbox. Zero spam, I promise.
-      </p>
-      <form
-        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[480px] gap-2"
-      >
-        <input
-          type="email"
-          name="email"
-          placeholder="user@domain.net"
-          required
-          aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-12 flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
-        />
-        <button
-          type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-12 rounded-full px-6 font-mono text-sm font-medium transition-colors"
-        >
-          SUBSCRIBE
-        </button>
-      </form>
-    </div>
+    <Newsletter
+      heading="Stay in the loop"
+      description="Thoughts delivered straight to your inbox. Zero spam, I promise."
+      buttonLabel="SUBSCRIBE"
+      class="bg-card p-12"
+    />
   </section>
 </MainLayout>

--- a/daniakash.com/src/pages/newsletter.astro
+++ b/daniakash.com/src/pages/newsletter.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import Newsletter from "../components/Newsletter.astro";
 import MainLayout from "../layouts/MainLayout.astro";
 
 const rss = (await getCollection("rss")).sort(
@@ -38,36 +39,13 @@ const years = [...issuesByYear.keys()].sort((a, b) => b - a);
     </header>
 
     <!-- Subscribe box -->
-    <div class="nl-subscribe mb-20 rounded-2xl border border-border bg-foreground/[0.025] p-6">
-      <div class="mb-2 font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
-        Stay up to date
-      </div>
-      <h2 class="mb-1 text-xl font-semibold">Get notified when I publish something new</h2>
-      <p class="mb-6 text-sm text-muted-foreground">Unsubscribe at any time. No spam, ever.</p>
-      <form
-        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="nl-subscribe__form flex gap-2"
-      >
-        <input
-          type="email"
-          name="email"
-          id="bd-email"
-          placeholder="you@email.com"
-          required
-          aria-label="Email address"
-          class="h-11 flex-1 rounded-full border border-border bg-foreground/5 px-6 font-mono text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary"
-        />
-        <button
-          type="submit"
-          class="h-11 rounded-full bg-primary px-6 font-mono text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-        >
-          Subscribe
-        </button>
-      </form>
-    </div>
+    <Newsletter
+      heading="Get notified when I publish something new"
+      description="Unsubscribe at any time. No spam, ever."
+      label="Stay up to date"
+      center={false}
+      class="mb-20 p-6"
+    />
 
     <!-- Issues list -->
     <div>
@@ -109,13 +87,3 @@ const years = [...issuesByYear.keys()].sort((a, b) => b - a);
   </div>
 </MainLayout>
 
-<style>
-  @media (max-width: 600px) {
-    .nl-subscribe__form {
-      flex-direction: column;
-    }
-    .nl-subscribe__form button {
-      width: 100%;
-    }
-  }
-</style>

--- a/daniakash.com/src/pages/newsletter.astro
+++ b/daniakash.com/src/pages/newsletter.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import Newsletter from "../components/Newsletter.astro";
+import NewsletterWidget from "../components/Newsletter.astro";
 import MainLayout from "../layouts/MainLayout.astro";
 
 const rss = (await getCollection("rss")).sort(
@@ -39,7 +39,7 @@ const years = [...issuesByYear.keys()].sort((a, b) => b - a);
     </header>
 
     <!-- Subscribe box -->
-    <Newsletter
+    <NewsletterWidget
       heading="Get notified when I publish something new"
       description="Unsubscribe at any time. No spam, ever."
       label="Stay up to date"

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import type { GetStaticPaths } from "astro";
 import { ASSET_PREFIX } from "../../constants/asset-prefix";
 import MainLayout from "../../layouts/MainLayout.astro";
+import Newsletter from "../../components/Newsletter.astro";
 import { getOGImage } from "../../utils/getOGImage";
 
 export const getStaticPaths = (async () => {
@@ -96,36 +97,11 @@ await getOGImage({
     />
 
     <!-- Subscribe CTA -->
-    <div
-      class="nl-subscribe border-border bg-foreground/[0.025] mt-20 rounded-xl border p-6 text-center"
-    >
-      <h3 class="mb-1 text-lg font-semibold">Enjoyed this issue?</h3>
-      <p class="text-muted-foreground mb-4 text-sm">
-        Subscribe to get future issues delivered to your inbox.
-      </p>
-      <form
-        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[400px] flex-col gap-2 sm:flex-row"
-      >
-        <input
-          type="email"
-          name="email"
-          placeholder="you@email.com"
-          required
-          aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-10 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
-        />
-        <button
-          type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-10 w-full rounded-full px-6 font-mono text-[13px] font-medium transition-colors sm:w-auto"
-        >
-          Subscribe
-        </button>
-      </form>
-    </div>
+    <Newsletter
+      heading="Enjoyed this issue?"
+      description="Subscribe to get future issues delivered to your inbox."
+      class="mt-20 rounded-xl p-6"
+    />
 
     <!-- Prev/Next navigation -->
     <div

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -116,7 +116,7 @@ await getOGImage({
           placeholder="you@email.com"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-10 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-10 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
         />
         <button
           type="submit"

--- a/daniakash.com/src/pages/newsletter/[...slug].astro
+++ b/daniakash.com/src/pages/newsletter/[...slug].astro
@@ -108,7 +108,7 @@ await getOGImage({
         method="post"
         target="popupwindow"
         onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="nl-subscribe__form mx-auto flex max-w-[400px] gap-2"
+        class="mx-auto flex max-w-[400px] flex-col gap-2 sm:flex-row"
       >
         <input
           type="email"
@@ -116,11 +116,11 @@ await getOGImage({
           placeholder="you@email.com"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-10 flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-10 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
         />
         <button
           type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-10 rounded-full px-6 font-mono text-[13px] font-medium transition-colors"
+          class="bg-primary text-primary-foreground hover:bg-primary/80 h-10 w-full rounded-full px-6 font-mono text-[13px] font-medium transition-colors sm:w-auto"
         >
           Subscribe
         </button>
@@ -159,14 +159,6 @@ await getOGImage({
   </article>
 </MainLayout>
 
-<style>
-
-  @media (max-width: 600px) {
-    .nl-subscribe__form {
-      flex-direction: column;
-    }
-  }
-</style>
 
 <script is:inline>
   document.addEventListener("astro:page-load", function () {

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -137,7 +137,7 @@ await getOGImage({
           placeholder="you@email.com"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
         />
         <button
           type="submit"

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -129,7 +129,7 @@ await getOGImage({
         method="post"
         target="popupwindow"
         onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[420px] gap-2"
+        class="mx-auto flex max-w-[420px] flex-col gap-2 sm:flex-row"
       >
         <input
           type="email"
@@ -137,11 +137,11 @@ await getOGImage({
           placeholder="you@email.com"
           required
           aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
+          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-6 font-mono text-sm transition-colors outline-none"
         />
         <button
           type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-11 rounded-full px-6 font-mono text-[13px] font-medium transition-colors"
+          class="bg-primary text-primary-foreground hover:bg-primary/80 h-11 w-full rounded-full px-6 font-mono text-[13px] font-medium transition-colors sm:w-auto"
         >
           Subscribe
         </button>

--- a/daniakash.com/src/pages/posts/[...slug].astro
+++ b/daniakash.com/src/pages/posts/[...slug].astro
@@ -6,6 +6,7 @@ import { PERSON_ENTITY_ID } from "../../constants/seo";
 import MainLayout from "../../layouts/MainLayout.astro";
 import { getDateDisplay } from "../../utils/getDateDisplay";
 import { getDateValue } from "../../utils/getDateValue";
+import Newsletter from "../../components/Newsletter.astro";
 import { getOGImage } from "../../utils/getOGImage";
 
 export const getStaticPaths = (async () => {
@@ -119,34 +120,11 @@ await getOGImage({
     </div>
 
     <!-- Subscribe box -->
-    <div class="mt-20 rounded-2xl border border-border bg-foreground/[0.025] p-8 text-center">
-      <h3 class="mb-2 text-xl font-semibold">Enjoyed this post?</h3>
-      <p class="text-muted-foreground mb-6 text-sm">
-        Get new posts delivered straight to your inbox. No spam, ever.
-      </p>
-      <form
-        action="https://buttondown.com/api/emails/embed-subscribe/daniakash"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.com/daniakash', 'popupwindow')"
-        class="mx-auto flex max-w-[420px] flex-col gap-2 sm:flex-row"
-      >
-        <input
-          type="email"
-          name="email"
-          placeholder="you@email.com"
-          required
-          aria-label="Email address"
-          class="border-border bg-foreground/5 text-foreground placeholder:text-muted-foreground focus:border-primary h-11 w-full flex-1 rounded-full border px-4 font-mono text-sm transition-colors outline-none sm:px-6"
-        />
-        <button
-          type="submit"
-          class="bg-primary text-primary-foreground hover:bg-primary/80 h-11 w-full rounded-full px-6 font-mono text-[13px] font-medium transition-colors sm:w-auto"
-        >
-          Subscribe
-        </button>
-      </form>
-    </div>
+    <Newsletter
+      heading="Enjoyed this post?"
+      description="Get new posts delivered straight to your inbox. No spam, ever."
+      class="mt-20"
+    />
 
     <!-- Article footer -->
     <div


### PR DESCRIPTION
## Problem

The subscribe box on post and newsletter pages uses a side-by-side `flex` row for the email input and submit button. At 320 px the button overflows 87 px to the right; at 375 px it still overflows 32 px.

## Fix

**`posts/[...slug].astro`**
- Form: `flex gap-2` → `flex flex-col gap-2 sm:flex-row`
- Input: added `w-full`
- Button: added `w-full sm:w-auto`

**`newsletter/[...slug].astro`**
- Same Tailwind changes applied
- Removed the now-redundant `@media (max-width: 600px) { .nl-subscribe__form { flex-direction: column } }` block (it only handled direction, not button width, and is fully replaced by the Tailwind classes)

## Behaviour after fix

| Breakpoint | Layout |
|---|---|
| < 640 px (mobile) | Form stacks — input full width, button full width below |
| ≥ 640 px (sm+) | Side-by-side row as before |