### PR TITLE
fix(nav): make hamburger menu survive Astro view transitions

### DIFF
--- a/daniakash.com/src/components/Nav.astro
+++ b/daniakash.com/src/components/Nav.astro
@@ -84,39 +84,52 @@ const currentPath = Astro.url.pathname;
   </div>
 </nav>
 
-<script>
-  const toggle = document.getElementById("mobile-menu-toggle");
-  const menu = document.getElementById("mobile-menu");
-  const hamburgerIcon = document.getElementById("hamburger-icon");
-  const closeIcon = document.getElementById("close-icon");
+<script is:inline>
+  document.addEventListener("astro:page-load", function () {
+    if (window.__mobileNavCleanup) window.__mobileNavCleanup();
 
-  function openMenu() {
-    menu?.classList.remove("hidden");
-    hamburgerIcon?.classList.add("hidden");
-    closeIcon?.classList.remove("hidden");
-    toggle?.setAttribute("aria-expanded", "true");
-  }
+    var toggle = document.getElementById("mobile-menu-toggle");
+    var menu = document.getElementById("mobile-menu");
+    var hamburgerIcon = document.getElementById("hamburger-icon");
+    var closeIcon = document.getElementById("close-icon");
 
-  function closeMenu() {
-    menu?.classList.add("hidden");
-    hamburgerIcon?.classList.remove("hidden");
-    closeIcon?.classList.add("hidden");
-    toggle?.setAttribute("aria-expanded", "false");
-  }
+    if (!toggle || !menu) return;
 
-  toggle?.addEventListener("click", () => {
-    const isOpen = toggle.getAttribute("aria-expanded") === "true";
-    if (isOpen) {
-      closeMenu();
-    } else {
-      openMenu();
+    function openMenu() {
+      menu.classList.remove("hidden");
+      if (hamburgerIcon) hamburgerIcon.classList.add("hidden");
+      if (closeIcon) closeIcon.classList.remove("hidden");
+      toggle.setAttribute("aria-expanded", "true");
     }
-  });
 
-  const mobileLinks = document.querySelectorAll(".mobile-nav-link");
-  mobileLinks.forEach((link) => {
-    link.addEventListener("click", () => {
-      closeMenu();
+    function closeMenu() {
+      menu.classList.add("hidden");
+      if (hamburgerIcon) hamburgerIcon.classList.remove("hidden");
+      if (closeIcon) closeIcon.classList.add("hidden");
+      toggle.setAttribute("aria-expanded", "false");
+    }
+
+    function handleToggle() {
+      if (toggle.getAttribute("aria-expanded") === "true") {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    }
+
+    var mobileLinks = document.querySelectorAll(".mobile-nav-link");
+
+    toggle.addEventListener("click", handleToggle);
+    mobileLinks.forEach(function (link) {
+      link.addEventListener("click", closeMenu);
     });
+
+    window.__mobileNavCleanup = function () {
+      toggle.removeEventListener("click", handleToggle);
+      mobileLinks.forEach(function (link) {
+        link.removeEventListener("click", closeMenu);
+      });
+      closeMenu();
+    };
   });
 </script>


### PR DESCRIPTION
## Problem

Same root cause as #25 — the hamburger menu script was a bundled `<script>` that only runs on initial page load. After any View Transition navigation the toggle stops working because the DOM is swapped but the script never re-runs.

## Fix

Same pattern applied in #25:

- `<script>` → `<script is:inline>`
- Wrapped in `document.addEventListener("astro:page-load", ...)` so it re-initialises on every navigation
- Queries all elements fresh on each run
- Stores cleanup on `window.__mobileNavCleanup` — called at the top of each run to remove old listeners and reset menu state before re-attaching

## Test plan
- [ ] Mobile viewport — open hamburger menu, navigate to a page, return — hamburger still works
- [ ] Open menu, click a nav link — menu closes and link navigates correctly
- [ ] Navigate 5+ times — no stacked event listeners, menu state resets correctly on each page