### PR TITLE
fix(seo): redirect /sitemap.xml to /sitemap-index.xml

### DIFF
--- a/daniakash.com/astro.config.mjs
+++ b/daniakash.com/astro.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig({
   site: SITE_URL,
   redirects: {
     "/blog/[...slug]": "/posts/[...slug]",
+    "/sitemap.xml": "/sitemap-index.xml",
   },
   prefetch: {
     defaultStrategy: "viewport",

--- a/daniakash.com/public/_redirects
+++ b/daniakash.com/public/_redirects
@@ -1,0 +1,1 @@
+/sitemap.xml /sitemap-index.xml 301

--- a/daniakash.com/public/_redirects
+++ b/daniakash.com/public/_redirects
@@ -1,1 +1,0 @@
-/sitemap.xml /sitemap-index.xml 301


### PR DESCRIPTION
## Problem

Google Search Console reports **"Sitemap is HTML"** for `/sitemap.xml`.

`@astrojs/sitemap` generates the sitemap at `/sitemap-index.xml`, not `/sitemap.xml`. When GSC (or `robots.txt`) references `/sitemap.xml`, Cloudflare Pages returns an HTML 404 — which GSC correctly rejects as not a valid sitemap format.

## Fix

Added `/sitemap.xml` → `/sitemap-index.xml` to Astro's `redirects` config alongside the existing `/blog/[...slug]` redirect.