### PR TITLE
fix(seo): set correct sitemap URL in robots.txt

### DIFF
--- a/daniakash.com/astro.config.mjs
+++ b/daniakash.com/astro.config.mjs
@@ -55,6 +55,7 @@ export default defineConfig({
       },
     }),
     robotsTxt({
+      sitemap: `${SITE_URL}/sitemap-index.xml`,
       policy: [
         {
           userAgent: "*",


### PR DESCRIPTION
## Problem

`astro-robots-txt` was not given an explicit sitemap URL, so it may default to `/sitemap.xml`. Google reads `robots.txt` to discover the sitemap — if it points to the wrong URL, Google won't find the real sitemap at `/sitemap-index.xml`.

## Fix

Added `sitemap: \`${SITE_URL}/sitemap-index.xml\`` to the `robotsTxt()` config. The generated `robots.txt` will now include:

```
Sitemap: https://daniakash.com/sitemap-index.xml
```

This tells Google (and all other crawlers) exactly where to find the sitemap.