### PR TITLE
docs(readme): add Current Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in
 ## Current Projects
 
 - 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — Open-source agentic browser. Let AI see, click, and ship the boring tabs for you.
-- 🖥️ **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
+- 📟 **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
 - 🧵 **[acpx](https://github.com/DaniAkash/acpx)** — Headless ACP toolkit. Talk to coding agents over the protocol, no UI required.
 - 🛠️ **[skills](https://github.com/DaniAkash/skills)** — A growing toolbox of agent skills I reach for every day.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ that lets AI see, interact with, and automate the web.
 
 Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in Chennai, India.
 
+## Current Projects
+
+- 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — Open-source agentic browser. Let AI see, click, and ship the boring tabs for you.
+- 🖥️ **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
+- 🧵 **[acpx](https://github.com/DaniAkash/acpx)** — Headless ACP toolkit. Talk to coding agents over the protocol, no UI required.
+- 🛠️ **[skills](https://github.com/DaniAkash/skills)** — A growing toolbox of agent skills I reach for every day.
+
 ## What I do
 
 I design and develop intelligent systems — from browser-native AI agents that navigate the web autonomously, to tools that make AI practical for everyday workflows. My work sits at the intersection of browser engineering, AI agents, and developer tooling.


### PR DESCRIPTION
## Summary

- Adds a `## Current Projects` section to the profile README highlighting the four projects I'm actively working on: BrowserOS, Agent Terminal, acpx, and skills.
- Each entry pairs an emoji with a one-liner so the list scans quickly.

## Test plan

- [ ] README renders correctly on github.com/DaniAkash
- [ ] All four project links resolve to the right repos