### PR TITLE
chore(clawpatch): set up automated review backlog for daniakash.com

### DIFF
--- a/daniakash.com/.clawpatch/config.json
+++ b/daniakash.com/.clawpatch/config.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "stateDir": ".clawpatch",
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "target/**",
+    ".build/**",
+    ".git/**",
+    ".clawpatch/**"
+  ],
+  "provider": {
+    "name": "codex",
+    "model": null
+  },
+  "commands": {
+    "typecheck": "pnpm typecheck",
+    "lint": "pnpm lint",
+    "format": "pnpm format",
+    "test": null
+  },
+  "review": {
+    "maxContextFiles": 24,
+    "maxOwnedFiles": 12,
+    "maxFindingsPerFeature": 10,
+    "minConfidenceToFix": "medium"
+  },
+  "git": {
+    "requireCleanWorktreeForFix": true,
+    "commit": false,
+    "openPr": false
+  }
+}

--- a/daniakash.com/.clawpatch/features/feat_config_0c1c23856a.json
+++ b/daniakash.com/.clawpatch/features/feat_config_0c1c23856a.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_0c1c23856a",
+  "title": "Project config tsconfig.json",
+  "summary": "Build, release, or quality configuration in tsconfig.json.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tsconfig.json",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tsconfig.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "config"
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095436-c57d55",
+      "kind": "review-error",
+      "summary": "codex provider failed: Error: No such file or directory (os error 2)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:54:36.736Z"
+    },
+    {
+      "runId": "20260517T095512-0e5e96",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:55:21.491Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:55:21.491Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_config_7528cb5b98.json
+++ b/daniakash.com/.clawpatch/features/feat_config_7528cb5b98.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_7528cb5b98",
+  "title": "Project config package.json",
+  "summary": "Build, release, or quality configuration in package.json.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "config"
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-config-7528cb5b98-8358e_c6d0455f73"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095436-c57d55",
+      "kind": "review-error",
+      "summary": "codex provider failed: Error: No such file or directory (os error 2)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:54:36.737Z"
+    },
+    {
+      "runId": "20260517T095512-0e5e96",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:56:29.331Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:56:29.331Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_126d1a8112.json
+++ b/daniakash.com/.clawpatch/features/feat_library_126d1a8112.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_126d1a8112",
+  "title": "Node source src/constants",
+  "summary": "Node/TypeScript source group src/constants with 5 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src/constants",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/constants/asset-prefix.ts",
+      "reason": "source group src/constants"
+    },
+    {
+      "path": "src/constants/navLinks.ts",
+      "reason": "source group src/constants"
+    },
+    {
+      "path": "src/constants/newsletter-rss.ts",
+      "reason": "source group src/constants"
+    },
+    {
+      "path": "src/constants/seo.ts",
+      "reason": "source group src/constants"
+    },
+    {
+      "path": "src/constants/transition-names.ts",
+      "reason": "source group src/constants"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095436-c57d55",
+      "kind": "review-error",
+      "summary": "codex provider failed: Error: No such file or directory (os error 2)\n",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:54:36.737Z"
+    },
+    {
+      "runId": "20260517T095512-0e5e96",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:55:26.231Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:55:26.231Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_30733ce202.json
+++ b/daniakash.com/.clawpatch/features/feat_library_30733ce202.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_30733ce202",
+  "title": "Node source src/pages",
+  "summary": "Node/TypeScript source file src/pages/rss.xml.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src/pages",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/pages/rss.xml.ts",
+      "reason": "source group src/pages"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-30733ce202-300f_97df64cc98"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095636-603ab6",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:01.679Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:01.679Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_481f66376c.json
+++ b/daniakash.com/.clawpatch/features/feat_library_481f66376c.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_481f66376c",
+  "title": "Node source src/utils",
+  "summary": "Node/TypeScript source group src/utils with 6 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src/utils",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/utils/cn.ts",
+      "reason": "source group src/utils"
+    },
+    {
+      "path": "src/utils/getDateDisplay.ts",
+      "reason": "source group src/utils"
+    },
+    {
+      "path": "src/utils/getDateValue.ts",
+      "reason": "source group src/utils"
+    },
+    {
+      "path": "src/utils/getOGImage.ts",
+      "reason": "source group src/utils"
+    },
+    {
+      "path": "src/utils/getYoutubeThumbnail.ts",
+      "reason": "source group src/utils"
+    },
+    {
+      "path": "src/utils/writeFileToDist.ts",
+      "reason": "source group src/utils"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-481f66376c-9664_92d65f2022",
+    "fnd_sig-feat-library-481f66376c-b6c5_a782a97fce"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "2 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:50.858Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:50.858Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_c79e5f55d9.json
+++ b/daniakash.com/.clawpatch/features/feat_library_c79e5f55d9.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_c79e5f55d9",
+  "title": "Node source src/components",
+  "summary": "Node/TypeScript source group src/components with 3 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src/components",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/components/AmbientCanvas.tsx",
+      "reason": "source group src/components"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "reason": "source group src/components"
+    },
+    {
+      "path": "src/components/ThemeToggle.tsx",
+      "reason": "source group src/components"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-c79e5f55d9-9b74_9203dfb988",
+    "fnd_sig-feat-library-c79e5f55d9-582e_bad9f9b06f",
+    "fnd_sig-feat-library-c79e5f55d9-4635_3a2a141562"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "3 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:58:01.492Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:58:01.492Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_f180a663ec.json
+++ b/daniakash.com/.clawpatch/features/feat_library_f180a663ec.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_f180a663ec",
+  "title": "Node package daniakash.com",
+  "summary": "Node package manifest at package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "daniakash.com",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "README.md",
+      "reason": "package context"
+    },
+    {
+      "path": "tsconfig.json",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-f180a663ec-aa4a_de5739bcf3"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:35.150Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:35.150Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_library_f8bf0b65a1.json
+++ b/daniakash.com/.clawpatch/features/feat_library_f8bf0b65a1.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_f8bf0b65a1",
+  "title": "Node source src",
+  "summary": "Node/TypeScript source file src/content.config.ts.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/content.config.ts",
+      "reason": "source group src"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-f8bf0b65a1-caf3_31f5aea435"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:35.982Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:35.982Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_release_4862937c51.json
+++ b/daniakash.com/.clawpatch/features/feat_release_4862937c51.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_4862937c51",
+  "title": "Package script lint",
+  "summary": "Package script 'lint': biome check .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:44.976Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:44.976Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_release_51170e0f9c.json
+++ b/daniakash.com/.clawpatch/features/feat_release_51170e0f9c.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_51170e0f9c",
+  "title": "Package script build",
+  "summary": "Package script 'build': astro check && astro build",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:45.202Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:45.202Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_release_734b842583.json
+++ b/daniakash.com/.clawpatch/features/feat_release_734b842583.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_734b842583",
+  "title": "Package script format",
+  "summary": "Package script 'format': biome format --write .",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "format",
+      "route": null,
+      "command": "format"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:52.473Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:52.473Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_release_775032a0f4.json
+++ b/daniakash.com/.clawpatch/features/feat_release_775032a0f4.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_775032a0f4",
+  "title": "Package script start",
+  "summary": "Package script 'start': astro dev",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "start",
+      "route": null,
+      "command": "start"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-release-775032a0f4-f0bf_eb81595ab1"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:58:01.360Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:58:01.360Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_release_a235aa99b1.json
+++ b/daniakash.com/.clawpatch/features/feat_release_a235aa99b1.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_a235aa99b1",
+  "title": "Package script typecheck",
+  "summary": "Package script 'typecheck': astro check",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "typecheck",
+      "route": null,
+      "command": "typecheck"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:daniakash.com",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:57:59.850Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:57:59.850Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_ui-flow_01d1997a91.json
+++ b/daniakash.com/.clawpatch/features/feat_ui-flow_01d1997a91.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_01d1997a91",
+  "title": "React component AmbientCanvas",
+  "summary": "React component implemented by src/components/AmbientCanvas.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "src/components/AmbientCanvas.tsx",
+      "symbol": "AmbientCanvas",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/components/AmbientCanvas.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "react",
+    "component",
+    "web"
+  ],
+  "trustBoundaries": [
+    "user-input",
+    "network",
+    "serialization"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:58:08.653Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:58:08.653Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_ui-flow_a5816877de.json
+++ b/daniakash.com/.clawpatch/features/feat_ui-flow_a5816877de.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_a5816877de",
+  "title": "React component ThemeToggle",
+  "summary": "React component implemented by src/components/ThemeToggle.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "src/components/ThemeToggle.tsx",
+      "symbol": "ThemeToggle",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/components/ThemeToggle.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "react",
+    "component",
+    "web"
+  ],
+  "trustBoundaries": [
+    "user-input",
+    "network",
+    "serialization"
+  ],
+  "status": "reviewed",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "0 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:58:18.797Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:58:18.797Z"
+}

--- a/daniakash.com/.clawpatch/features/feat_ui-flow_e084b0b622.json
+++ b/daniakash.com/.clawpatch/features/feat_ui-flow_e084b0b622.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_ui-flow_e084b0b622",
+  "title": "React component Globe",
+  "summary": "React component implemented by src/components/Globe.tsx.",
+  "kind": "ui-flow",
+  "source": "react-component",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "src/components/Globe.tsx",
+      "symbol": "Globe",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/components/Globe.tsx",
+      "reason": "component implementation"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "src/constants/asset-prefix.ts",
+      "reason": "direct import"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "react",
+    "component",
+    "web"
+  ],
+  "trustBoundaries": [
+    "user-input",
+    "network",
+    "serialization"
+  ],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-ui-flow-e084b0b622-dc18_f20170e910",
+    "fnd_sig-feat-ui-flow-e084b0b622-f0a4_14ccd969c1",
+    "fnd_sig-feat-ui-flow-e084b0b622-a14f_009a0a991a"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T095713-0fd29e",
+      "kind": "review",
+      "summary": "3 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T09:59:29.072Z"
+    }
+  ],
+  "createdAt": "2026-05-17T09:54:23.433Z",
+  "updatedAt": "2026-05-17T09:59:29.072Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-config-7528cb5b98-8358e_c6d0455f73.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-config-7528cb5b98-8358e_c6d0455f73.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-config-7528cb5b98-8358e_c6d0455f73",
+  "featureId": "feat_config_7528cb5b98",
+  "title": "No package test script or included test suite",
+  "category": "test-gap",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "test-gap",
+  "evidence": [
+    {
+      "path": "package.json",
+      "startLine": 6,
+      "endLine": 15,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "The project exposes dev, build, typecheck, lint, and format scripts, but no `test` script. The feature metadata also lists no linked tests, so package-level quality gates can validate formatting, linting, and Astro type/build checks without exercising behavioral regressions in components, routes, content utilities, or config integration.",
+  "reproduction": null,
+  "recommendation": "Add a package-level `test` script that runs the project's chosen test suite, or explicitly document that this project has no automated behavioral tests and why build/typecheck/lint are sufficient.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests are linked for this feature, and `package.json` does not define a `test` command for package-manager-driven test execution.",
+  "suggestedRegressionTest": "Add a minimal test runner configuration and a `pnpm test` script, then include at least one smoke test for an Astro page or utility that is expected to remain stable.",
+  "minimumFixScope": "Update `package.json` to include a test script and add the minimal supporting test files/configuration needed for it to run in CI or local quality checks.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-config-7528cb5b98_8358e595f4",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095512-0e5e96",
+  "createdAt": "2026-05-17T09:56:29.331Z",
+  "updatedAt": "2026-05-17T09:56:29.331Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-30733ce202-300f_97df64cc98.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-30733ce202-300f_97df64cc98.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-30733ce202-300f_97df64cc98",
+  "featureId": "feat_library_30733ce202",
+  "title": "RSS generation can emit an invalid feed when Astro site is unset",
+  "category": "api-contract",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "contract-mismatch",
+  "evidence": [
+    {
+      "path": "src/pages/rss.xml.ts",
+      "startLine": 12,
+      "endLine": 15,
+      "symbol": "GET",
+      "quote": "return rss({\n    title: \"Dani Akash’s Blog\",\n    description:\n      \"Where my thoughts get some air time (and occasionally make sense).\",\n    site: context.site ?? \"\","
+    }
+  ],
+  "reasoning": "@astrojs/rss uses the `site` option as the base URL for feed and item links. Falling back to an empty string hides the missing-site case and can produce invalid absolute URLs or fail RSS generation depending on runtime behavior. This route only supplies relative item links, so the feed depends on a valid site base.",
+  "reproduction": null,
+  "recommendation": "Require a configured absolute site URL instead of silently using an empty string. For example, throw a clear error when `context.site` is absent, or pass a known canonical URL from configuration.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests were included for this feature, and there is no RSS route test that exercises generation without `context.site`.",
+  "suggestedRegressionTest": "Add a route/unit test that calls `GET` with `context.site` undefined and asserts it fails with a clear configuration error, plus a valid-site case that verifies item links are absolute.",
+  "minimumFixScope": "Update `src/pages/rss.xml.ts` to validate `context.site` before calling `rss()`.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-30733ce202_300fcfa3ef",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095636-603ab6",
+  "createdAt": "2026-05-17T09:57:01.678Z",
+  "updatedAt": "2026-05-17T09:57:01.678Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-481f66376c-9664_92d65f2022.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-481f66376c-9664_92d65f2022.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-481f66376c-9664_92d65f2022",
+  "featureId": "feat_library_481f66376c",
+  "title": "Date-only strings can render as the previous calendar day in negative time zones",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "src/utils/getDateDisplay.ts",
+      "startLine": 2,
+      "endLine": 7,
+      "symbol": "getDateDisplay",
+      "quote": "const dateObject = new Date(date);\n  return dateObject.toLocaleDateString(\"en-US\", {"
+    },
+    {
+      "path": "src/utils/getDateValue.ts",
+      "startLine": 2,
+      "endLine": 3,
+      "symbol": "getDateValue",
+      "quote": "const dateObject = new Date(date);\n  return dateObject.toISOString().split(\"T\")[0]!;"
+    }
+  ],
+  "reasoning": "The utilities parse incoming strings with `new Date(date)`. For ISO date-only inputs such as `2026-05-17`, JavaScript interprets the value as midnight UTC. `getDateDisplay` then formats it in the runtime's local timezone because no `timeZone` is specified, so users or builds running in negative offsets can display May 16, 2026 while `getDateValue` still emits `2026-05-17`. This creates inconsistent date display/value behavior for the same date source.",
+  "reproduction": "In a negative timezone such as America/Los_Angeles: `new Date(\"2026-05-17\").toLocaleDateString(\"en-US\", { year: \"numeric\", month: \"long\", day: \"numeric\" })` returns `May 16, 2026`.",
+  "recommendation": "For date-only content values, either parse the `YYYY-MM-DD` parts as a local calendar date or format with a fixed `timeZone: \"UTC\"` consistently across both helpers.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests are included for these utilities, and timezone-dependent behavior is not exercised.",
+  "suggestedRegressionTest": "Add a test that formats a date-only string under a negative timezone and asserts that `getDateDisplay(\"2026-05-17\")` remains `May 17, 2026` and `getDateValue(\"2026-05-17\")` remains `2026-05-17`.",
+  "minimumFixScope": "Update date parsing/formatting in `src/utils/getDateDisplay.ts` and keep behavior aligned with `src/utils/getDateValue.ts`.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-481f66376c_9664ba7561",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:57:50.857Z",
+  "updatedAt": "2026-05-17T09:57:50.857Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-481f66376c-b6c5_a782a97fce.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-481f66376c-b6c5_a782a97fce.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-481f66376c-b6c5_a782a97fce",
+  "featureId": "feat_library_481f66376c",
+  "title": "Dist file writes can escape the intended output directory",
+  "category": "security",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "src/utils/writeFileToDist.ts",
+      "startLine": 5,
+      "endLine": 9,
+      "symbol": "writeFileToDist",
+      "quote": "const imagePath = resolve(process.cwd(), `${targetDir}${filePath}`);\n  const imageDir = dirname(imagePath);\n  mkdirSync(imageDir, { recursive: true });\n  writeFileSync(imagePath, fileBuffer);"
+    },
+    {
+      "path": "src/utils/getOGImage.ts",
+      "startLine": 13,
+      "endLine": 18,
+      "symbol": "getOGImage",
+      "quote": "path,\n}: {\n  title: string;\n  description: string;\n  path: string;\n  cover?: string;"
+    },
+    {
+      "path": "src/utils/getOGImage.ts",
+      "startLine": 107,
+      "endLine": 107,
+      "symbol": "getOGImage",
+      "quote": "writeFileToDist(path, imageFile);"
+    }
+  ],
+  "reasoning": "`writeFileToDist` concatenates `targetDir` and caller-provided `filePath`, resolves the result, and writes it without checking that the resolved path remains under `public` or `dist`. A path containing traversal after a leading slash, such as `/../package.json`, resolves outside the target directory and can overwrite files in the project root. `getOGImage` passes its `path` parameter directly to this helper, so any caller mistake or content-derived path can become an arbitrary project-file write during dev/build.",
+  "reproduction": "Calling `writeFileToDist('/../tmp-owned', Buffer.from('x'))` from the project root writes to `<project>/tmp-owned` instead of `<project>/dist/tmp-owned` or `<project>/public/tmp-owned`.",
+  "recommendation": "Normalize `filePath` as a relative path, reject absolute paths and any `..` traversal segments, then verify the final resolved path starts with the resolved target output directory before writing.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests are included for `writeFileToDist`, and no negative cases cover traversal or absolute-style input.",
+  "suggestedRegressionTest": "Add tests that assert normal paths write under the selected output directory and that `/../...`, `../...`, and absolute paths are rejected without writing files.",
+  "minimumFixScope": "Harden `src/utils/writeFileToDist.ts` path handling; optionally validate `path` before passing it from `getOGImage`.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-481f66376c_b6c5c7dfa8",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:57:50.857Z",
+  "updatedAt": "2026-05-17T09:57:50.857Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-4635_3a2a141562.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-4635_3a2a141562.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-c79e5f55d9-4635_3a2a141562",
+  "featureId": "feat_library_c79e5f55d9",
+  "title": "Globe crashes when rendered with an empty destinations array",
+  "category": "api-contract",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "contract-mismatch",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 100,
+      "endLine": 105,
+      "symbol": "GlobeProps",
+      "quote": "destinations: DestinationInput[];"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 110,
+      "endLine": 115,
+      "symbol": "Globe",
+      "quote": "Math.floor(Math.random() * DESTINATIONS.length),"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 128,
+      "endLine": 128,
+      "symbol": "Globe",
+      "quote": "const d = DESTINATIONS[currentIdx]!;"
+    }
+  ],
+  "reasoning": "The public prop type permits any array, including an empty one. With no destinations, startIdx becomes 0 and DESTINATIONS[0] is undefined; initialPhi immediately dereferences .loc, so the component throws during render instead of showing an empty state or rejecting the input explicitly.",
+  "reproduction": null,
+  "recommendation": "Either make the prop contract non-empty at the type/API boundary or add a runtime empty-state guard before computing startIdx, initialPhi, and d.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests cover the empty destinations case or component API validation.",
+  "suggestedRegressionTest": "Render <Globe destinations={[]} /> and assert it does not throw and displays the intended empty state, or assert a deliberate validation error if the API is changed to require non-empty input.",
+  "minimumFixScope": "src/components/Globe.tsx initial destination selection and render guard.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-c79e5f55d9_463511f0b5",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:58:01.491Z",
+  "updatedAt": "2026-05-17T09:58:01.491Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-582e_bad9f9b06f.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-582e_bad9f9b06f.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-c79e5f55d9-582e_bad9f9b06f",
+  "featureId": "feat_library_c79e5f55d9",
+  "title": "Resize handler never resizes the cobe canvas",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 202,
+      "endLine": 211,
+      "symbol": "Globe useEffect",
+      "quote": "const w = wrap.offsetWidth;\nconst h = wrap.offsetHeight;"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 315,
+      "endLine": 328,
+      "symbol": "handleResize",
+      "quote": "observer.disconnect();\n// Trigger re-mount by observer logic\nobserver.observe(document.documentElement, {"
+    }
+  ],
+  "reasoning": "The globe is created with fixed pixel dimensions derived from the wrapper size at mount. The resize handler only disconnects and reconnects the theme MutationObserver; it does not recreate the globe, call update with new dimensions, or mutate the observed class attribute. A window resize therefore leaves cobe rendering at stale dimensions while the wrapper and overlay projection use current offsetWidth/offsetHeight, causing visual stretching/misalignment after viewport changes.",
+  "reproduction": null,
+  "recommendation": "Handle resize by debouncing a real globe recreation or cobe size update using the latest wrapper dimensions, and keep the overlay projection and canvas dimensions derived from the same size source.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests exercise window resizing or assert canvas dimensions after resize.",
+  "suggestedRegressionTest": "Mount Globe, record the cobe creation dimensions, change the wrapper/window size, dispatch resize, advance the debounce timer, and assert the globe is recreated or updated with the new dimensions.",
+  "minimumFixScope": "src/components/Globe.tsx resize handler and globe creation/update path.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-c79e5f55d9_582ec51dae",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:58:01.491Z",
+  "updatedAt": "2026-05-17T09:58:01.491Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-9b74_9203dfb988.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-c79e5f55d9-9b74_9203dfb988.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-c79e5f55d9-9b74_9203dfb988",
+  "featureId": "feat_library_c79e5f55d9",
+  "title": "Theme toggle restarts the globe without marker-overlay synchronization",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 227,
+      "endLine": 265,
+      "symbol": "animate",
+      "quote": "const finalPhi = phiRef.current + r.get();\nglobe.update({ phi: finalPhi });"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 282,
+      "endLine": 308,
+      "symbol": "MutationObserver callback",
+      "quote": "markers: [{ location: DESTINATIONS[currentIdx]!.loc, size: 0.03 }],"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 237,
+      "endLine": 257,
+      "symbol": "animate",
+      "quote": "const dest = DESTINATIONS[currentIdxRef.current]!;"
+    }
+  ],
+  "reasoning": "The normal animation loop updates both the globe rotation and the polaroid overlay position, using currentIdxRef for the active destination. On a theme class mutation, the code destroys the globe, cancels that loop, and starts animateNew, which only updates phi. It also recreates cobe with DESTINATIONS[currentIdx] from the effect's initial render closure rather than currentIdxRef. After the user navigates to another destination and toggles theme, the globe marker can reset to the initial destination while the visible card remains frozen or points at the current destination, breaking the marker/card contract.",
+  "reproduction": null,
+  "recommendation": "When recreating the globe for theme changes, use the same animation path as the initial globe or extract a shared create/restart routine that keeps marker selection and overlay positioning in sync. Use currentIdxRef.current for the marker location inside long-lived callbacks.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are included for Globe interactions, theme changes, or marker/card synchronization.",
+  "suggestedRegressionTest": "Render Globe with at least two destinations, switch to the second destination, toggle the document dark class, and assert the recreated globe marker and polaroid content/position both correspond to the second destination.",
+  "minimumFixScope": "src/components/Globe.tsx theme observer and animation-loop setup.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-c79e5f55d9_9b74994c8c",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:58:01.491Z",
+  "updatedAt": "2026-05-17T09:58:01.491Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-f180a663ec-aa4a_de5739bcf3.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-f180a663ec-aa4a_de5739bcf3.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-f180a663ec-aa4a_de5739bcf3",
+  "featureId": "feat_library_f180a663ec",
+  "title": "README documents npm workflows while the package declares pnpm",
+  "category": "docs-gap",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "docs-gap",
+  "evidence": [
+    {
+      "path": "package.json",
+      "startLine": 5,
+      "endLine": 5,
+      "symbol": "packageManager",
+      "quote": "\"packageManager\": \"pnpm@10.33.0\""
+    },
+    {
+      "path": "README.md",
+      "startLine": 31,
+      "endLine": 37,
+      "symbol": null,
+      "quote": "`npm install` / `npm run dev` / `npm run build`"
+    }
+  ],
+  "reasoning": "The manifest opts the project into pnpm via packageManager, but the README tells contributors to install and run scripts with npm. That can lead to a different lockfile/resolution path and confusing onboarding for a pnpm-managed project.",
+  "reproduction": null,
+  "recommendation": "Update the README command table and setup instructions to use pnpm equivalents such as `pnpm install`, `pnpm dev`, `pnpm build`, `pnpm preview`, and `pnpm astro ...`.",
+  "whyTestsDoNotAlreadyCoverThis": "No tests or documentation checks are linked for this package feature, and command documentation is not validated by the current scripts.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "README.md command/setup documentation only.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-f180a663ec_aa4a9b66ad",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:57:35.150Z",
+  "updatedAt": "2026-05-17T09:57:35.150Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-f8bf0b65a1-caf3_31f5aea435.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-library-f8bf0b65a1-caf3_31f5aea435.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-f8bf0b65a1-caf3_31f5aea435",
+  "featureId": "feat_library_f8bf0b65a1",
+  "title": "External RSS content can make builds fail nondeterministically",
+  "category": "build-release",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "src/content.config.ts",
+      "startLine": 169,
+      "endLine": 184,
+      "symbol": "rss",
+      "quote": "const feed = await parse(NEWSLETTER_RSS);"
+    },
+    {
+      "path": "package.json",
+      "startLine": 7,
+      "endLine": 9,
+      "symbol": "scripts.build",
+      "quote": "\"build\": \"astro check && astro build\""
+    }
+  ],
+  "reasoning": "The Astro content collection loader fetches and parses a remote newsletter RSS feed during content loading. Because `astro build` invokes Astro's content pipeline, a transient network outage, RSS server error, malformed feed item, or changed item shape can fail the site build even when repository content is unchanged. There is no fallback to cached/local content and no error handling around the remote parse or per-item URL parsing.",
+  "reproduction": null,
+  "recommendation": "Wrap the RSS load in explicit error handling and use a deterministic fallback, such as a checked-in snapshot/cache or an empty collection with a logged warning, depending on whether newsletter content is required for release correctness.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are included for the RSS loader or build behavior under remote feed failure.",
+  "suggestedRegressionTest": "Add a loader-level test or small integration harness that mocks `parse(NEWSLETTER_RSS)` throwing and asserts the collection loader handles it according to the chosen fallback policy.",
+  "minimumFixScope": "Update the `rss` collection loader in `src/content.config.ts` to handle remote parse failures and invalid item links without aborting normal builds.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-library-f8bf0b65a1_caf39bebb0",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:57:35.981Z",
+  "updatedAt": "2026-05-17T09:57:35.981Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-release-775032a0f4-f0bf_eb81595ab1.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-release-775032a0f4-f0bf_eb81595ab1.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-release-775032a0f4-f0bf_eb81595ab1",
+  "featureId": "feat_release_775032a0f4",
+  "title": "`start` runs the Astro development server instead of a production server",
+  "category": "build-release",
+  "severity": "medium",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "package.json",
+      "startLine": 8,
+      "endLine": 8,
+      "symbol": "scripts.start",
+      "quote": "\"start\": \"astro dev\""
+    },
+    {
+      "path": "package.json",
+      "startLine": 10,
+      "endLine": 10,
+      "symbol": "scripts.preview",
+      "quote": "\"preview\": \"astro preview\""
+    }
+  ],
+  "reasoning": "The package `start` entrypoint is commonly used by release tooling and Node hosts as the production launch command, but it currently starts `astro dev`. That runs the development server rather than serving the built output, while the package already has a separate `preview` script for serving a built Astro site. In environments that invoke `pnpm start`, this can deploy a dev server path instead of the production artifact path.",
+  "reproduction": "Run `pnpm start` after a production build; it invokes `astro dev` rather than `astro preview` or another production adapter command.",
+  "recommendation": "Point `start` at the intended production command, such as `astro preview` for serving built output locally, or the deployment adapter/server entrypoint if this app is meant to run on a Node host. Keep `dev` as the development-only command.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests or release checks exercise the package `start` script or assert that it serves production build output.",
+  "suggestedRegressionTest": "Add a release smoke check that runs the build and then validates the configured start command uses the production serving path rather than `astro dev`.",
+  "minimumFixScope": "Update the `scripts.start` value in `package.json` and, if needed, add a lightweight release smoke check for the start command.",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-release-775032a0f4_f0bf1b761e",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:58:01.359Z",
+  "updatedAt": "2026-05-17T09:58:01.359Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-a14f_009a0a991a.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-a14f_009a0a991a.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-ui-flow-e084b0b622-a14f_009a0a991a",
+  "featureId": "feat_ui-flow_e084b0b622",
+  "title": "Theme-change globe recreation uses stale marker index",
+  "category": "bug",
+  "severity": "low",
+  "confidence": "medium",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 270,
+      "endLine": 293,
+      "symbol": "MutationObserver callback",
+      "quote": "const newGlobe = createGlobe(canvas, {\n        devicePixelRatio: 2,\n        width: wrap.offsetWidth * 2,\n        height: wrap.offsetHeight * 2,\n        phi: phiRef.current,\n        theta: 0.15,\n        dark: dark ? 1 : 0,\n        diffuse: 1.2,\n        mapSamples: 16000,\n        mapBrightness: 6,\n        mapBaseBrightness: 0.05,\n        baseColor: dark ? [0.3, 0.3, 0.3] : [1, 1, 1],\n        markerColor: dark ? [0.18, 0.83, 0.75] : [0.05, 0.58, 0.53],\n        glowColor: dark ? [0.15, 0.15, 0.2] : [1, 1, 1],\n        markers: [{ location: DESTINATIONS[currentIdx]!.loc, size: 0.03 }],\n      });"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 337,
+      "endLine": 345,
+      "symbol": "Globe useEffect",
+      "quote": "return () => {\n      if (globeRef.current) globeRef.current.destroy();\n      if (animRef.current) cancelAnimationFrame(animRef.current);\n      if (cycleRef.current) clearInterval(cycleRef.current);\n      if (progressTimerRef.current) clearInterval(progressTimerRef.current);\n      observer.disconnect();\n      window.removeEventListener(\"resize\", handleResize);\n    };\n  }, []);"
+    }
+  ],
+  "reasoning": "The effect intentionally runs only once, so the MutationObserver callback closes over the initial currentIdx value. After the user navigates to another destination, a class mutation for dark/light theme recreates cobe with markers for the initial destination while the panel and currentIdxRef-driven overlay continue to point at the selected destination. The next manual or timer navigation repairs the marker, but until then the globe marker and clickable polaroid can disagree.",
+  "reproduction": "Render with at least two destinations, navigate to the second destination, then toggle the documentElement dark class. The recreated cobe instance is initialized with DESTINATIONS[currentIdx] from the mount-time closure rather than currentIdxRef.current.",
+  "recommendation": "In the observer callback, initialize markers from DESTINATIONS[currentIdxRef.current] or centralize marker selection through the same ref used by the animation overlay.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are provided, and there is no test covering navigation followed by a theme class mutation.",
+  "suggestedRegressionTest": "Add a component test that switches destination, triggers a documentElement class mutation, and asserts createGlobe receives the currently selected destination marker.",
+  "minimumFixScope": "src/components/Globe.tsx",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-ui-flow-e084b0b622_a14f523cd8",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:59:29.071Z",
+  "updatedAt": "2026-05-17T09:59:29.071Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-dc18_f20170e910.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-dc18_f20170e910.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-ui-flow-e084b0b622-dc18_f20170e910",
+  "featureId": "feat_ui-flow_e084b0b622",
+  "title": "Empty destination lists crash during render",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 110,
+      "endLine": 116,
+      "symbol": "Globe",
+      "quote": "const [startIdx] = useState(() =>\n    Math.floor(Math.random() * DESTINATIONS.length),\n  );\n  const [currentIdx, setCurrentIdx] = useState(startIdx);\n  const initialPhi =\n    -(DESTINATIONS[startIdx]!.loc[1] * (Math.PI / 180)) - Math.PI / 2;"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 141,
+      "endLine": 145,
+      "symbol": "switchTo",
+      "quote": "const wrapped =\n        ((idx % DESTINATIONS.length) + DESTINATIONS.length) %\n        DESTINATIONS.length;"
+    }
+  ],
+  "reasoning": "When destinations is empty, startIdx becomes 0, but DESTINATIONS[0] is undefined. The non-null assertion then dereferences .loc during render, so the component throws before it can display any fallback. The same zero-length case also makes index wrapping use modulo zero and produce NaN in navigation paths.",
+  "reproduction": "Render <Globe destinations={[]} />; the render evaluates DESTINATIONS[startIdx]!.loc and throws because DESTINATIONS[0] is undefined.",
+  "recommendation": "Handle an empty mapped destination list before deriving startIdx/current destination, either by rendering an empty-state UI or returning null. Also guard navigation helpers so they do not modulo by zero.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are provided for Globe, and there is no test exercising an empty destinations prop.",
+  "suggestedRegressionTest": "Add a component test that renders Globe with an empty destinations array and asserts it does not throw and shows the intended empty state.",
+  "minimumFixScope": "src/components/Globe.tsx",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-ui-flow-e084b0b622_dc18b19a94",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:59:29.071Z",
+  "updatedAt": "2026-05-17T09:59:29.071Z"
+}

--- a/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-f0a4_14ccd969c1.json
+++ b/daniakash.com/.clawpatch/findings/fnd_sig-feat-ui-flow-e084b0b622-f0a4_14ccd969c1.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-ui-flow-e084b0b622-f0a4_14ccd969c1",
+  "featureId": "feat_ui-flow_e084b0b622",
+  "title": "Resize handler never resizes or recreates the globe",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 209,
+      "endLine": 213,
+      "symbol": "Globe useEffect",
+      "quote": "const globe = createGlobe(canvas, {\n      devicePixelRatio: 2,\n      width: w * 2,\n      height: h * 2,"
+    },
+    {
+      "path": "src/components/Globe.tsx",
+      "startLine": 324,
+      "endLine": 336,
+      "symbol": "handleResize",
+      "quote": "const handleResize = () => {\n      clearTimeout(resizeTimeout);\n      resizeTimeout = setTimeout(() => {\n        observer.disconnect();\n        // Trigger re-mount by observer logic\n        observer.observe(document.documentElement, {\n          attributes: true,\n          attributeFilter: [\"class\"],\n        });\n      }, 200);\n    };"
+    }
+  ],
+  "reasoning": "The globe canvas dimensions are captured from the wrapper only when createGlobe is called. On resize, the handler only disconnects and re-attaches the MutationObserver; that does not mutate the document class and does not call createGlobe, update the canvas width/height, or update cobe dimensions. After the wrapper changes size, the rendered globe can remain at the old bitmap dimensions while overlay projection uses the new wrapper dimensions, causing a blurry or misaligned globe and marker card.",
+  "reproduction": "Mount the component, resize the viewport so .globe-wrap changes dimensions, and observe that handleResize does not recreate or update the cobe instance with the new width/height.",
+  "recommendation": "Replace the resize handler with logic that actually resizes/recreates the cobe instance using the current wrapper dimensions, or factor globe creation into a shared function used by mount, theme changes, and resize. Keep the overlay projection and canvas dimensions sourced from the same measured size.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests are provided, and there is no resize behavior test or visual regression coverage for the canvas and overlay alignment.",
+  "suggestedRegressionTest": "Add a browser/component test that changes the wrapper size and asserts createGlobe/update receives dimensions based on the new wrapper size, or a visual test that verifies marker overlay alignment after resize.",
+  "minimumFixScope": "src/components/Globe.tsx",
+  "status": "open",
+  "history": [],
+  "signature": "sig_feat-ui-flow-e084b0b622_f0a48495eb",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260517T095713-0fd29e",
+  "createdAt": "2026-05-17T09:59:29.071Z",
+  "updatedAt": "2026-05-17T09:59:29.071Z"
+}

--- a/daniakash.com/.clawpatch/project.json
+++ b/daniakash.com/.clawpatch/project.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "projectId": "prj_https-github-com-daniakash-dania_33ff6886bf",
+  "name": "daniakash.com",
+  "rootPath": "daniakash.com",
+  "git": {
+    "remoteUrl": "https://github.com/DaniAkash/DaniAkash.git",
+    "defaultBranch": "main",
+    "currentBranch": "chore/clawpatch-setup",
+    "headSha": "1536123e98a0e3b03b3905b7f63aef8b29c903a8"
+  },
+  "detected": {
+    "languages": [
+      "typescript",
+      "javascript"
+    ],
+    "frameworks": [],
+    "packageManagers": [
+      "pnpm"
+    ],
+    "commands": {
+      "typecheck": "pnpm typecheck",
+      "lint": "pnpm lint",
+      "format": "pnpm format",
+      "test": null
+    }
+  },
+  "createdAt": "2026-05-17T09:54:05.981Z",
+  "updatedAt": "2026-05-17T09:54:05.981Z"
+}

--- a/daniakash.com/.gitignore
+++ b/daniakash.com/.gitignore
@@ -35,3 +35,9 @@ public/og/
 
 # Ignore locally installed models
 models/
+
+# clawpatch — keep the durable map + findings, ignore ephemeral state
+.clawpatch/runs/
+.clawpatch/patches/
+.clawpatch/reports/
+.clawpatch/locks/

--- a/daniakash.com/package.json
+++ b/daniakash.com/package.json
@@ -12,7 +12,8 @@
     "typecheck": "astro check",
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "clawpr": "node ./scripts/clawpr.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",

--- a/daniakash.com/scripts/clawpr.mjs
+++ b/daniakash.com/scripts/clawpr.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
 const HELP = `Usage:
   pnpm clawpr           Review this branch's changed features and post a comment on the open PR.
-  pnpm clawpr --all     Review the whole repo and write a report under .clawpatch/reports/.
+  pnpm clawpr --all     Review the whole repo and print the report path.
   pnpm clawpr --help    Show this help.
 `;
 
@@ -28,13 +28,13 @@ function runStreaming(cmd, args) {
   });
 }
 
-function runCapture(cmd, args) {
+function runCapture(cmd, args, opts = {}) {
   return new Promise((resolveP, rejectP) => {
-    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", opts.teeStderr ? "inherit" : "pipe"] });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => (stdout += d));
-    child.stderr.on("data", (d) => (stderr += d));
+    if (child.stderr) child.stderr.on("data", (d) => (stderr += d));
     child.on("error", rejectP);
     child.on("exit", (code) => {
       if (code === 0) resolveP({ stdout, stderr });
@@ -57,6 +57,11 @@ async function openPr() {
   }
 }
 
+function parseReportPath(reviewStdout) {
+  const match = reviewStdout.match(/^report:\s*(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
 async function reviewPr() {
   const branch = await currentBranch();
   if (branch === "main" || branch === "master") {
@@ -72,14 +77,22 @@ async function reviewPr() {
   const base = `origin/${pr.baseRefName}`;
 
   logStatus(`reviewing changes vs ${base} (PR #${pr.number})`);
-  await runStreaming("clawpatch", ["review", "--root", ROOT, "--since", base, "--jobs", "4"]);
+  const { stdout } = await runCapture(
+    "clawpatch",
+    ["review", "--root", ROOT, "--since", base, "--jobs", "4"],
+    { teeStderr: true },
+  );
+  process.stdout.write(stdout);
 
-  const reportPath = join(tmpdir(), `clawpr-report-${Date.now()}.md`);
-  await runStreaming("clawpatch", ["report", "--root", ROOT, "--since", base, "-o", reportPath]);
+  const reportPath = parseReportPath(stdout);
+  if (!reportPath) {
+    logStatus("no features changed in this branch; nothing to post");
+    return;
+  }
 
   const reportStat = await stat(reportPath).catch(() => null);
   if (!reportStat || reportStat.size === 0) {
-    logStatus("empty report; skipping PR comment");
+    logStatus("report file empty; skipping PR comment");
     return;
   }
 
@@ -94,16 +107,19 @@ async function reviewPr() {
 
 async function reviewAll() {
   logStatus("running full-repo review (no PR scope)");
-  await runStreaming("clawpatch", ["review", "--root", ROOT, "--jobs", "4"]);
+  const { stdout } = await runCapture(
+    "clawpatch",
+    ["review", "--root", ROOT, "--jobs", "4"],
+    { teeStderr: true },
+  );
+  process.stdout.write(stdout);
 
-  const reportDir = join(ROOT, ".clawpatch", "reports");
-  await mkdir(reportDir, { recursive: true });
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
-  const reportPath = join(reportDir, `full-${stamp}.md`);
-  await runStreaming("clawpatch", ["report", "--root", ROOT, "-o", reportPath]);
-
+  const reportPath = parseReportPath(stdout);
+  if (!reportPath) {
+    logStatus("no pending features to review");
+    return;
+  }
   logStatus(`full report written to ${reportPath}`);
-  process.stdout.write(`${reportPath}\n`);
 }
 
 async function main() {

--- a/daniakash.com/scripts/clawpr.mjs
+++ b/daniakash.com/scripts/clawpr.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+
+const HELP = `Usage:
+  pnpm clawpr           Review this branch's changed features and post a comment on the open PR.
+  pnpm clawpr --all     Review the whole repo and write a report under .clawpatch/reports/.
+  pnpm clawpr --help    Show this help.
+`;
+
+const ROOT = process.cwd();
+
+function logStatus(msg) {
+  process.stderr.write(`clawpr: ${msg}\n`);
+}
+
+function runStreaming(cmd, args) {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("error", rejectP);
+    child.on("exit", (code) => {
+      if (code === 0) resolveP();
+      else rejectP(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+function runCapture(cmd, args) {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", rejectP);
+    child.on("exit", (code) => {
+      if (code === 0) resolveP({ stdout, stderr });
+      else rejectP(Object.assign(new Error(`${cmd} exited with code ${code}`), { stdout, stderr, code }));
+    });
+  });
+}
+
+async function currentBranch() {
+  const { stdout } = await runCapture("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  return stdout.trim();
+}
+
+async function openPr() {
+  try {
+    const { stdout } = await runCapture("gh", ["pr", "view", "--json", "number,baseRefName"]);
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function reviewPr() {
+  const branch = await currentBranch();
+  if (branch === "main" || branch === "master") {
+    logStatus(`refusing to run on ${branch}`);
+    process.exit(2);
+  }
+
+  const pr = await openPr();
+  if (!pr) {
+    logStatus("no open PR for this branch; run 'gh pr create' first or pass --all for a full-repo review");
+    process.exit(2);
+  }
+  const base = `origin/${pr.baseRefName}`;
+
+  logStatus(`reviewing changes vs ${base} (PR #${pr.number})`);
+  await runStreaming("clawpatch", ["review", "--root", ROOT, "--since", base, "--jobs", "4"]);
+
+  const reportPath = join(tmpdir(), `clawpr-report-${Date.now()}.md`);
+  await runStreaming("clawpatch", ["report", "--root", ROOT, "--since", base, "-o", reportPath]);
+
+  const reportStat = await stat(reportPath).catch(() => null);
+  if (!reportStat || reportStat.size === 0) {
+    logStatus("empty report; skipping PR comment");
+    return;
+  }
+
+  const reportBody = await readFile(reportPath, "utf8");
+  const header = `## 🩹 clawpatch review (auto)\n\n_Scoped to features changed vs \`${base}\`. Local Codex review — ignore findings that do not apply._\n\n`;
+  const commentPath = join(tmpdir(), `clawpr-comment-${Date.now()}.md`);
+  await writeFile(commentPath, header + reportBody, "utf8");
+
+  await runStreaming("gh", ["pr", "comment", String(pr.number), "--body-file", commentPath]);
+  logStatus(`posted review on PR #${pr.number}`);
+}
+
+async function reviewAll() {
+  logStatus("running full-repo review (no PR scope)");
+  await runStreaming("clawpatch", ["review", "--root", ROOT, "--jobs", "4"]);
+
+  const reportDir = join(ROOT, ".clawpatch", "reports");
+  await mkdir(reportDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
+  const reportPath = join(reportDir, `full-${stamp}.md`);
+  await runStreaming("clawpatch", ["report", "--root", ROOT, "-o", reportPath]);
+
+  logStatus(`full report written to ${reportPath}`);
+  process.stdout.write(`${reportPath}\n`);
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      options: {
+        all: { type: "boolean", default: false },
+        help: { type: "boolean", short: "h", default: false },
+      },
+      strict: true,
+      allowPositionals: false,
+    });
+  } catch (err) {
+    logStatus(err.message);
+    process.stderr.write(HELP);
+    process.exit(2);
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  if (parsed.values.all) {
+    await reviewAll();
+    return;
+  }
+  await reviewPr();
+}
+
+main().catch((err) => {
+  logStatus(err.message || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add clawpatch state under `daniakash.com/.clawpatch/` driven by the local Codex CLI. 16 features mapped, 13 initial findings persisted so the review backlog survives across context switches.
- `.gitignore` excludes ephemeral state (`runs/`, `patches/`, `reports/`, `locks/`); commits the durable `config.json`, `project.json`, `features/`, and `findings/`.
- Add `daniakash.com/scripts/clawpr.mjs` and a `clawpr` package script for an on-demand local review workflow.

## How `pnpm clawpr` works

From inside `daniakash.com/`:

- **`pnpm clawpr`** — default mode. Requires an open PR for the current branch; runs a diff-scoped review against the PR's base, then posts the markdown report as a PR comment. Re-running on the same PR adds another comment (useful after pushing more commits).
- **`pnpm clawpr --all`** — full-repo audit. Reviews every pending feature and writes a timestamped report to `.clawpatch/reports/full-<ts>.md`. Does not touch any PR.

The script is zero-dep Node (`node:util parseArgs`, `node:child_process`, `node:fs/promises`) so it can be lifted into a standalone npm package later without a rewrite.

## Test plan

- [ ] `pnpm install` resolves cleanly.
- [ ] `pnpm build` and `pnpm typecheck` still pass.
- [ ] `pnpm clawpr --help` prints usage.
- [ ] `pnpm clawpr` from inside `daniakash.com/` on this branch reviews diff-scoped features and either posts a comment or reports an empty diff cleanly.
- [ ] `pnpm clawpr --all` from inside `daniakash.com/` re-runs the full sweep.