### PR TITLE
docs(readme): rename acpx entry to agent-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in
 
 - 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — Open-source agentic browser. Let AI see, click, and ship the boring tabs for you.
 - 📟 **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
-- 🧵 **[agent-toolkit](https://github.com/DaniAkash/agent-toolkit)**: toolkit for AI coding agents. Vercel AI SDK adapters, a local microVM sandbox, skill and MCP installers, ACP-protocol utilities.
+- 🧵 **[agent-toolkit](https://github.com/DaniAkash/agent-toolkit)** — Vercel AI SDK adapters, a local microVM sandbox, skill and MCP installers, ACP-protocol utilities.
 - 🛠️ **[skills](https://github.com/DaniAkash/skills)** — A growing toolbox of agent skills I reach for every day.
 - 🎨 **[stylecn](https://github.com/DaniAkash/stylecn)** — Brand-themed presets for shadcn/ui. Apple, Stripe, Linear, Airbnb, and more — copy the CSS, ship the look.
 - 🌲 **[worktree-env-copy](https://github.com/DaniAkash/worktree-env-copy)** — Global git post-checkout hook that auto-copies .env* files into new worktrees. Built for AI coding agents that spin up worktrees on demand.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in
 
 - 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — Open-source agentic browser. Let AI see, click, and ship the boring tabs for you.
 - 📟 **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
-- 🧵 **[acpx](https://github.com/DaniAkash/acpx)** — Headless ACP toolkit. Talk to coding agents over the protocol, no UI required.
+- 🧵 **[agent-toolkit](https://github.com/DaniAkash/agent-toolkit)**: toolkit for AI coding agents. Vercel AI SDK adapters, a local microVM sandbox, skill and MCP installers, ACP-protocol utilities.
 - 🛠️ **[skills](https://github.com/DaniAkash/skills)** — A growing toolbox of agent skills I reach for every day.
 - 🎨 **[stylecn](https://github.com/DaniAkash/stylecn)** — Brand-themed presets for shadcn/ui. Apple, Stripe, Linear, Airbnb, and more — copy the CSS, ship the look.
 - 🌲 **[worktree-env-copy](https://github.com/DaniAkash/worktree-env-copy)** — Global git post-checkout hook that auto-copies .env* files into new worktrees. Built for AI coding agents that spin up worktrees on demand.


### PR DESCRIPTION
## Summary

`DaniAkash/acpx` was renamed to `DaniAkash/agent-toolkit` to reflect its broader scope. Half the packages there now serve non-ACP coding-agent workflows (a HarnessV1 sandbox provider, a skills installer, an MCP-server installer) alongside the original ACP tooling.

This PR updates the Current Projects entry:

- Link points at the new repo URL.
- Tagline rewritten from "Headless ACP toolkit" to one that actually names what's inside (Vercel AI SDK adapters, local microVM sandbox, skill and MCP installers, ACP-protocol utilities).

## Test plan

- [x] Link resolves to the renamed repo.
- [x] Visual rendering preserved in the Current Projects list.