### PR TITLE
docs: add herbie and mac-mcp to current projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Founding Engineer at [browseros-ai](https://github.com/browseros-ai) · Based in
 
 - 🌐 **[BrowserOS](https://github.com/browseros-ai/BrowserOS)** — Open-source agentic browser. Let AI see, click, and ship the boring tabs for you.
 - 📟 **[Agent Terminal](https://github.com/DaniAkash/agent-terminal)** — A terminal where coding agents are first-class citizens, not bolted-on guests.
+- 🤖 **[herbie](https://github.com/DaniAkash/herbie)** — One menubar window for every AI coding agent. Pick Claude, Codex, or Gemini, share skills across them, drive them from your phone.
 - 🧵 **[agent-toolkit](https://github.com/DaniAkash/agent-toolkit)** — Vercel AI SDK adapters, a local microVM sandbox, skill and MCP installers, ACP-protocol utilities.
+- 🍎 **[mac-mcp](https://github.com/DaniAkash/mac-mcp)** — Read-only MCP server that exposes native macOS apps (Mail, Calendar, Reminders, Contacts, Notes, Messages, Spotlight) to AI agents.
 - 🛠️ **[skills](https://github.com/DaniAkash/skills)** — A growing toolbox of agent skills I reach for every day.
 - 🎨 **[stylecn](https://github.com/DaniAkash/stylecn)** — Brand-themed presets for shadcn/ui. Apple, Stripe, Linear, Airbnb, and more — copy the CSS, ship the look.
 - 🌲 **[worktree-env-copy](https://github.com/DaniAkash/worktree-env-copy)** — Global git post-checkout hook that auto-copies .env* files into new worktrees. Built for AI coding agents that spin up worktrees on demand.


### PR DESCRIPTION
Adds two more open-source projects to the Current Projects list on the profile README.

- **herbie** — one menubar window for every AI coding agent (Claude, Codex, Gemini), with shared skills and phone access.
- **mac-mcp** — read-only MCP server exposing native macOS apps (Mail, Calendar, Reminders, Contacts, Notes, Messages, Spotlight) to AI agents.

herbie sits next to Agent Terminal as an agent UX surface; mac-mcp sits next to agent-toolkit as MCP/agent tooling. Both bullets match the existing emoji + bold + one-line format.